### PR TITLE
Command buffer

### DIFF
--- a/Arch.Test/Arch.Test.csproj
+++ b/Arch.Test/Arch.Test.csproj
@@ -12,15 +12,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>
-        <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Arch\Arch.csproj"/>
+        <ProjectReference Include="..\Arch\Arch.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Arch.Test/CommandBufferTest.cs
+++ b/Arch.Test/CommandBufferTest.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using Arch.Core;
+using Arch.Core.CommandBuffer;
+using Arch.Core.Extensions;
+using Arch.Core.Utils;
+
+namespace Arch.Test;
+
+[TestFixture]
+public class CommandBufferTest
+{
+
+    private static readonly Type[] _group = { typeof(Transform), typeof(Rotation) };
+    private readonly QueryDescription _queryDescription = new QueryDescription { All = _group };
+
+    [Test]
+    public void CommandBufferSparseSet()
+    {
+        
+        var mySet = new SparseSet();
+        
+        var first = mySet.Create(new Entity(0, 0, 0));
+        mySet.Set(first, new Transform{ X = 10, Y = 10});
+        var transform = mySet.Get<Transform>(first);
+        
+        var second = mySet.Create(new Entity(0, 0, 0));
+        mySet.Set(second, new Rotation{ X = 10, Y = 10});
+        var rotation = mySet.Get<Rotation>(second);
+        
+        Assert.AreEqual(10, transform.X);
+        Assert.AreEqual(10, rotation.X);
+    }
+    
+    [Test]
+    public void DestructionBuffer()
+    {
+        var world = World.Create();
+        var buffer = new DestructionBuffer(world, 1000);
+        for (var index = 0; index < 1000; index++)
+            world.Create(new Transform{ X = 10}, new Rotation{ W = 10});
+        
+        Assert.AreEqual(1000, world.Size);
+        
+        world.Query(in _queryDescription, buffer.Destroy);
+        buffer.Playback();
+        
+        Assert.AreEqual(0, world.Size);
+        World.Destroy(world);
+    }
+    
+    [Test]
+    public void CreationBuffer()
+    {
+        var world = World.Create();
+        var buffer = new CreationBuffer(world);
+        
+        var entity = buffer.Create(_group);
+        buffer.Set(in entity, new Transform{ X = 10 });
+        buffer.Set(in entity, new Rotation{ W = 10 });
+        
+        var secondEntity = buffer.Create(_group);
+        buffer.Set(in secondEntity, new Transform{ X = 10 });
+        buffer.Set(in secondEntity, new Rotation{ W = 10 });
+        
+        buffer.Playback();
+        
+        Assert.AreEqual(2, world.Size);
+
+        var entities = new List<Entity>();
+        world.GetEntities(in _queryDescription, entities);
+        Assert.AreEqual(10, entities[0].Get<Transform>().X);
+        Assert.AreEqual(10, entities[0].Get<Rotation>().W);
+        Assert.AreEqual(10, entities[1].Get<Transform>().X);
+        Assert.AreEqual(10, entities[1].Get<Rotation>().W);
+        
+        World.Destroy(world);
+    }
+}

--- a/Arch.Test/CommandBufferTest.cs
+++ b/Arch.Test/CommandBufferTest.cs
@@ -133,7 +133,7 @@ public partial class CommandBufferTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _jobScheduler = new JobScheduler.JobScheduler("Test");
+        _jobScheduler = new JobScheduler.JobScheduler("CommandBuffer");
     }
 
     [OneTimeTearDown]
@@ -181,7 +181,6 @@ public partial class CommandBufferTest
         buffer.Playback();
         
         Assert.AreEqual(2000, world.Size);
-
         World.Destroy(world);
     }
     

--- a/Arch.Test/CommandBufferTest.cs
+++ b/Arch.Test/CommandBufferTest.cs
@@ -75,4 +75,43 @@ public class CommandBufferTest
         
         World.Destroy(world);
     }
+    
+    [Test]
+    public void ModificationBuffer()
+    {
+        var world = World.Create();
+        var buffer = new ModificationBuffer(world);
+
+        var entity = world.Create(_group);
+        var bufferedEntity = buffer.Modify(in entity);
+        buffer.Set(in bufferedEntity, new Transform{ X = 10 });
+        buffer.Set(in bufferedEntity, new Rotation{ X = 10 });
+        
+        buffer.Playback();
+        
+        var entities = new List<Entity>();
+        world.GetEntities(in _queryDescription, entities);
+        Assert.AreEqual(10, entities[0].Get<Transform>().X);
+        Assert.AreEqual(10, entities[0].Get<Rotation>().X);
+        
+        World.Destroy(world);
+    }
+    
+    [Test]
+    public void StructuralBuffer()
+    {
+        var world = World.Create();
+        var buffer = new StructuralBuffer(world);
+
+        var entity = world.Create(_group);
+        buffer.Add<Ai>(in entity);
+        
+        buffer.Playback();
+        
+        var entities = new List<Entity>();
+        world.GetEntities(in _queryDescription, entities);
+        Assert.AreEqual(true, entities[0].Has<Ai>());
+
+        World.Destroy(world);
+    }
 }

--- a/Arch.Test/CommandBufferTest.cs
+++ b/Arch.Test/CommandBufferTest.cs
@@ -7,10 +7,11 @@ using Arch.Core.Utils;
 namespace Arch.Test;
 
 [TestFixture]
-public class CommandBufferTest
+public partial class CommandBufferTest
 {
 
     private static readonly Type[] _group = { typeof(Transform), typeof(Rotation) };
+    private static readonly Type[] _secondGroup = { typeof(Transform), typeof(Rotation), typeof(Ai), typeof(int) };
     private readonly QueryDescription _queryDescription = new QueryDescription { All = _group };
 
     [Test]
@@ -89,10 +90,8 @@ public class CommandBufferTest
         
         buffer.Playback();
         
-        var entities = new List<Entity>();
-        world.GetEntities(in _queryDescription, entities);
-        Assert.AreEqual(10, entities[0].Get<Transform>().X);
-        Assert.AreEqual(10, entities[0].Get<Rotation>().X);
+        Assert.AreEqual(10, entity.Get<Transform>().X);
+        Assert.AreEqual(10, entity.Get<Rotation>().X);
         
         World.Destroy(world);
     }
@@ -102,16 +101,78 @@ public class CommandBufferTest
     {
         var world = World.Create();
         var buffer = new StructuralBuffer(world);
-
+        
         var entity = world.Create(_group);
-        buffer.Add<Ai>(in entity);
+        var secondEntity = world.Create(_secondGroup);
+        
+        var addToEntity = buffer.BatchAdd(in entity);
+        buffer.Add<Ai>(in addToEntity);
+        buffer.Add<int>(in addToEntity);
+        
+        var removeFromEntity = buffer.BatchRemove(in secondEntity);
+        buffer.Remove<Ai>(in removeFromEntity);
+        buffer.Remove<int>(in removeFromEntity);
         
         buffer.Playback();
         
-        var entities = new List<Entity>();
-        world.GetEntities(in _queryDescription, entities);
-        Assert.AreEqual(true, entities[0].Has<Ai>());
+        Assert.AreEqual(true, entity.Has<Ai, int>());
+        Assert.AreEqual(false, secondEntity.Has<Ai, int>());
+        
 
         World.Destroy(world);
+    }
+}
+
+
+[TestFixture]
+public partial class CommandBufferTest
+{
+    
+    [Test]
+    public void ParallelDestructionBuffer()
+    {
+
+        var scheduler = new JobScheduler.JobScheduler("Arch");
+        
+        var world = World.Create();
+        var buffer = new DestructionBuffer(world, 1000);
+        for (var index = 0; index < 1000; index++)
+            world.Create(new Transform{ X = 10}, new Rotation{ W = 10});
+        
+        Assert.AreEqual(1000, world.Size);
+        
+        world.ParallelQuery(in _queryDescription, buffer.Destroy);
+        buffer.Playback();
+        
+        Assert.AreEqual(0, world.Size);
+        World.Destroy(world);
+        scheduler.Dispose();
+    }
+    
+    [Test]
+    public void ParallelCreationBuffer()
+    {
+        var scheduler = new JobScheduler.JobScheduler("Arch");
+        
+        var world = World.Create();
+        var buffer = new CreationBuffer(world);
+        for (var index = 0; index < 1000; index++)
+            world.Create(new Transform{ X = 10}, new Rotation{ W = 10});
+        
+                
+        world.ParallelQuery(in _queryDescription, (in Entity entity1) => {
+            
+            var entity = buffer.Create(_group);
+            buffer.Set(in entity, new Transform{ X = 10 });
+            buffer.Set(in entity, new Rotation{ W = 10 });
+        });
+
+
+        buffer.Playback();
+        
+        Assert.AreEqual(2000, world.Size);
+
+        World.Destroy(world);
+        scheduler.Dispose();
     }
 }

--- a/Arch.Test/QueryTest.cs
+++ b/Arch.Test/QueryTest.cs
@@ -5,6 +5,17 @@ namespace Arch.Test;
 [TestFixture]
 public class QueryTest
 {
+    
+    private JobScheduler.JobScheduler _jobScheduler;
+    private World _world;
+
+    private readonly Type[] _entityGroup = { typeof(Transform), typeof(Rotation) };
+    private readonly Type[] _entityAiGroup = { typeof(Transform), typeof(Rotation), typeof(Ai) };
+
+    private readonly QueryDescription _withoutAiQuery = new() { All = new[] { typeof(Transform) }, Any = new[] { typeof(Rotation) }, None = new[] { typeof(Ai) } };
+    private readonly QueryDescription _allQuery = new() { All = new[] { typeof(Transform), typeof(Rotation) }, Any = new[] { typeof(Ai) } };
+
+    
     [OneTimeSetUp]
     public void Setup()
     {
@@ -16,17 +27,7 @@ public class QueryTest
     {
         _jobScheduler.Dispose();
     }
-
-    private JobScheduler.JobScheduler _jobScheduler;
-    private World _world;
-
-    private readonly Type[] _entityGroup = { typeof(Transform), typeof(Rotation) };
-    private readonly Type[] _entityAiGroup = { typeof(Transform), typeof(Rotation), typeof(Ai) };
-
-    private readonly QueryDescription _withoutAiQuery = new() { All = new[] { typeof(Transform) }, Any = new[] { typeof(Rotation) }, None = new[] { typeof(Ai) } };
-
-    private readonly QueryDescription _allQuery = new() { All = new[] { typeof(Transform), typeof(Rotation) }, Any = new[] { typeof(Ai) } };
-
+    
     [Test]
     public void AllQuery()
     {

--- a/Arch/Core/Archetype.cs
+++ b/Arch/Core/Archetype.cs
@@ -220,9 +220,22 @@ public sealed unsafe partial class Archetype
     }
 
     /// <summary>
+    /// Returns the <see cref="Chunk"/> for the passed <see cref="Entity"/> within this archetype.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>A referecene to the chunk in which the passed entity is stored in.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref Chunk GetChunk(in Entity entity)
+    {
+        var chunkIndex = EntityIdToChunkIndex[entity.EntityId];
+        return ref Chunks[chunkIndex];
+    }
+
+    /// <summary>
     ///     Returns a <see cref="Enumerator{T}" /> for <see cref="Chunks" /> to iterate over all chunks in this archetype.
     /// </summary>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator<Chunk> GetEnumerator()
     {
         return new Enumerator<Chunk>(Chunks.AsSpan(), Size);

--- a/Arch/Core/CommandBuffer/CreationBuffer.cs
+++ b/Arch/Core/CommandBuffer/CreationBuffer.cs
@@ -86,7 +86,7 @@ internal class LinearArchetype
         var id = ComponentMeta<T>.Id;
         var arrayIndex = _lookupArray[id];
         var components = _componentsArray[arrayIndex];
-        var array = Unsafe.As<T[]>(component);
+        var array = Unsafe.As<T[]>(components);
 
         lock (components)
         { 
@@ -96,26 +96,26 @@ internal class LinearArchetype
 }
 
 /// <summary>
+/// Represents a created entity. 
+/// </summary>
+public readonly ref struct BufferedEntity
+{
+    internal readonly int _index;
+    internal readonly LinearArchetype _archetype;
+
+    internal BufferedEntity(int index, LinearArchetype archetype)
+    {
+        _index = index;
+        _archetype = archetype;
+    }
+}
+
+/// <summary>
 /// A buffer used to buffer the creation of entities. 
 /// </summary>
 public struct CreationBuffer
 {
-    
-    /// <summary>
-    /// Represents a created entity. 
-    /// </summary>
-    public readonly ref struct BufferedEntity
-    {
-        internal readonly int _index;
-        internal readonly LinearArchetype _archetype;
 
-        internal BufferedEntity(int index, LinearArchetype archetype)
-        {
-            _index = index;
-            _archetype = archetype;
-        }
-    }
-    
     internal World _world;
     internal int _capacity;
     internal Dictionary<int, LinearArchetype> _archetypes;

--- a/Arch/Core/CommandBuffer/CreationBuffer.cs
+++ b/Arch/Core/CommandBuffer/CreationBuffer.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Arch.Core.Extensions;
+using Arch.Core.Utils;
+
+namespace Arch.Core.CommandBuffer;
+
+/// <summary>
+/// A archetype variation used to store buffered entities and their components.
+/// Its more lightweight and faster for this purpose. 
+/// Does not use chunks, neither has a real representation of entities... basically a plain multiple array storage. 
+/// </summary>
+internal class LinearArchetype
+{
+    internal Type[] _types;
+    
+    internal int _size;
+    internal int _capacity;
+    
+    internal Array[] _components;
+    internal int[] _lookupArray; 
+
+    internal LinearArchetype(Type[] types, int capacity = 64)
+    {
+        _types = types;
+        
+        // Allocate arrays and map 
+        _lookupArray = types.ToLookupArray();
+        _components = new Array[types.Length];
+        for (var index = 0; index < types.Length; index++)
+        {
+            var type = types[index];
+            _components[index] = Array.CreateInstance(type, capacity);
+        }
+
+        _capacity = capacity;
+    }
+
+    /// <summary>
+    /// Adds an row/entity to the archetype.
+    /// </summary>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Add()
+    {
+        // Increase internal capacities when full
+        if (_size >= _capacity)
+        {
+            for (var i = 0; i < _components.Length; i++)
+            {
+                var type = _types[i];
+                var components = _components[i];
+                var newArray = Array.CreateInstance(type, _capacity * 2);
+                components.CopyTo(newArray, 0);
+                _components[i] = newArray;
+            }
+        }
+        
+        var index = _size;
+        _size++;
+        return index;
+    }
+
+    /// <summary>
+    /// Sets an component for a row/entity. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(int index, in T component)
+    {
+        var id = ComponentMeta<T>.Id;
+        var arrayIndex = _lookupArray[id];
+        var array = Unsafe.As<T[]>(_components[arrayIndex]);
+
+        lock (array)
+        { 
+            array[index] = component;
+        }
+    }
+}
+
+/// <summary>
+/// A buffer used to buffer the creation of entities. 
+/// </summary>
+public struct CreationBuffer
+{
+    
+    /// <summary>
+    /// Represents a created entity. 
+    /// </summary>
+    public readonly ref struct CreatedEntity
+    {
+        internal readonly int _index;
+        internal readonly LinearArchetype _archetype;
+
+        internal CreatedEntity(int index, LinearArchetype archetype)
+        {
+            _index = index;
+            _archetype = archetype;
+        }
+    }
+    
+    internal World _world;
+    internal Dictionary<int, LinearArchetype> _archetypes;
+    
+    internal CreationBuffer(World world)
+    {
+        _world = world;
+        _archetypes = new Dictionary<int, LinearArchetype>(8);
+    }
+
+    /// <summary>
+    /// Gets or creates an archetype. 
+    /// </summary>
+    /// <param name="types"></param>
+    /// <param name="archetype"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void GetOrCreateArchetype(Type[] types, out LinearArchetype archetype)
+    {
+        var hash = ComponentMeta.GetHashCode(types);
+        if (_archetypes.TryGetValue(hash, out archetype)) return;
+        
+        archetype = new LinearArchetype(types);
+        _archetypes[hash] = archetype;
+    }
+    
+    /// <summary>
+    /// Creates an entity by a set of types. 
+    /// </summary>
+    /// <param name="types"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public CreatedEntity Create(Type[] types)
+    {
+        
+        GetOrCreateArchetype(types, out var archetype);
+        var archetypeIndex = archetype.Add();
+        return new CreatedEntity(archetypeIndex, archetype);
+    }
+
+    /// <summary>
+    /// Sets a component for a created entity. 
+    /// </summary>
+    /// <param name="createdEntity"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(in CreatedEntity createdEntity, in T component)
+    {
+        var archetype = createdEntity._archetype;
+        archetype.Set(createdEntity._index, in component);
+    }
+
+    /// <summary>
+    /// Plays back all buffered operations to create the entities into the real world. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Playback()
+    {
+        foreach (var kvp in _archetypes)
+        {
+            var commandBufferArchetype = kvp.Value;
+            var components = commandBufferArchetype._components;
+            
+            var archetype = _world.GetOrCreate(commandBufferArchetype._types);
+            _world.Reserve(commandBufferArchetype._types, commandBufferArchetype._size);
+            
+            // Create buffered entities into the real world and copy their components. 
+            for (var i = 0; i < commandBufferArchetype._size; i++)
+            {
+                var entity = _world.Create(commandBufferArchetype._types);
+                ref var chunk = ref archetype.GetChunk(in entity);
+                var entityIndex = chunk.EntityIdToIndex[entity.EntityId];
+                
+                // Move/Copy components to the new chunk
+                for (var j = 0; j < components.Length; j++)
+                {
+                    var sourceArray = components[j];
+                    var desArray = chunk.Components[j];
+                    Array.Copy(sourceArray, i, desArray, entityIndex, 1);
+                }
+            }
+        } 
+    }
+}

--- a/Arch/Core/CommandBuffer/DestructionBuffer.cs
+++ b/Arch/Core/CommandBuffer/DestructionBuffer.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Arch.Core.CommandBuffer;
+
+/// <summary>
+/// A buffer which can buffer destroy operations to play them back later.
+/// Playback should ONLY happen on the mainthread and not during a Query ! 
+/// </summary>
+public struct DestructionBuffer : IDisposable
+{
+    internal World _world;
+    internal List<Entity> _destroy;
+
+    public DestructionBuffer(World world, int initCapacity = 64)
+    {
+        _world = world;
+        _destroy = new List<Entity>(initCapacity);
+    }
+
+    /// <summary>
+    /// Buffers a destruction request for the passed <see cref="Entity"/>.
+    /// On <see cref="Playback"/> the entity will be destroyed. 
+    /// </summary>
+    /// <param name="entity"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Destroy(in Entity entity)
+    {
+        lock (_destroy)
+        {
+            _destroy.Add(entity);
+        }
+    }
+
+    /// <summary>
+    /// Plays back this buffer and executes all recorded operations. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Playback()
+    {
+        foreach (var entity in _destroy)
+            _world.Destroy(in entity);
+        
+        Dispose();
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        _destroy.Clear();
+    }
+}

--- a/Arch/Core/CommandBuffer/DestructionBuffer.cs
+++ b/Arch/Core/CommandBuffer/DestructionBuffer.cs
@@ -12,7 +12,15 @@ namespace Arch.Core.CommandBuffer;
 /// </summary>
 public struct DestructionBuffer : IDisposable
 {
-    internal World _world;
+    
+    /// <summary>
+    /// The world this buffer playbacks to.
+    /// </summary>
+    public World World { get; }
+    
+    /// <summary>
+    /// The internal list of entities to destroy upon playback. 
+    /// </summary>
     internal List<Entity> _destroy;
 
     /// <summary>
@@ -22,7 +30,7 @@ public struct DestructionBuffer : IDisposable
     /// <param name="initCapacity">The initial capacity.</param>
     public DestructionBuffer(World world, int initCapacity = 64)
     {
-        _world = world;
+        World = world;
         _destroy = new List<Entity>(initCapacity);
     }
 
@@ -47,7 +55,7 @@ public struct DestructionBuffer : IDisposable
     public void Playback()
     {
         foreach (var entity in _destroy)
-            _world.Destroy(in entity);
+            World.Destroy(in entity);
         
         Dispose();
     }

--- a/Arch/Core/CommandBuffer/DestructionBuffer.cs
+++ b/Arch/Core/CommandBuffer/DestructionBuffer.cs
@@ -15,6 +15,11 @@ public struct DestructionBuffer : IDisposable
     internal World _world;
     internal List<Entity> _destroy;
 
+    /// <summary>
+    /// Creates a destruction buffer.
+    /// </summary>
+    /// <param name="world">The world this playbacks to.</param>
+    /// <param name="initCapacity">The initial capacity.</param>
     public DestructionBuffer(World world, int initCapacity = 64)
     {
         _world = world;

--- a/Arch/Core/CommandBuffer/ModificationBuffer.cs
+++ b/Arch/Core/CommandBuffer/ModificationBuffer.cs
@@ -235,6 +235,11 @@ public struct ModificationBuffer : IDisposable
     internal World _world;
     internal SparseSet _sparseSet;
 
+    /// <summary>
+    /// Creates a modification buffer.
+    /// </summary>
+    /// <param name="world">The world this buffer playbacks to.</param>
+    /// <param name="capacity">The initial capcity, grows once it was reached.</param>
     internal ModificationBuffer(World world, int capacity = 64)
     {
         _world = world;

--- a/Arch/Core/CommandBuffer/ModificationBuffer.cs
+++ b/Arch/Core/CommandBuffer/ModificationBuffer.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Arch.Core.Extensions;
+using Arch.Core.Utils;
+using CommunityToolkit.HighPerformance;
+
+namespace Arch.Core.CommandBuffer;
+
+/// <summary>
+/// A sparse array, an alternative to archetypes.
+/// </summary>
+internal class SparseArray : IDisposable
+{
+
+    internal Type _type;
+    internal int _size;
+    internal int[] _entities;
+    internal Array _components;
+
+    public SparseArray(Type type)
+    {
+        _type = type;
+        _size = 0;
+        _entities = Array.Empty<int>();
+        _components = Array.CreateInstance(type, 1);
+    }
+
+    /// <summary>
+    /// Adds an entity to this sparse array.
+    /// </summary>
+    /// <param name="index"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(int index)
+    {
+        
+        // Resize entities
+        if (index >= _entities.Length)
+        {
+            Array.Resize(ref _entities, index+1);
+            Array.Fill(_entities, -1, _size, index);
+        }
+
+        _entities[index] = _size;
+        _size++;
+
+        // Resize components
+        if (_size < _components.Length) return;
+        
+        var array = Array.CreateInstance(_type, _components.Length*2);
+        _components.CopyTo(array, 0);
+        _components = array;
+    }
+    
+    /// <summary>
+    /// Returns true if this sparsearray contains an entity. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Has(int index)
+    {
+        return index < _entities.Length && _entities[index] != -1;
+    }
+
+    /// <summary>
+    /// Returns the sparsearray casted to a generic
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private T[] GetArray<T>()
+    {
+        return Unsafe.As<T[]>(_components);
+    }
+
+    /// <summary>
+    /// Sets a component for the entity. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    public void Set<T>(int index, in T component)
+    {
+        GetArray<T>()[_entities[index]] = component;
+    }
+
+    /// <summary>
+    /// Returns a component for the entity. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public ref T Get<T>(int index)
+    {
+        return ref GetArray<T>()[_entities[index]];
+    }
+
+    /// <summary>
+    /// Disposes this array. 
+    /// </summary>
+    public void Dispose()
+    {
+        _size = 0;
+    }
+}
+
+/// <summary>
+/// A sparset which is an alternative to an archetype. Has some advantages, for example less copy around stuff and easier archetype changes. 
+/// </summary>
+internal class SparseSet : IDisposable
+{
+
+    /// <summary>
+    /// Represents an entity, combined to a internal sparset index id for fast lookups.
+    /// </summary>
+    internal readonly struct WrappedEntity
+    {
+        internal readonly Entity _entity;
+        internal readonly int _index;
+
+        public WrappedEntity(Entity entity, int index)
+        {
+            _entity = entity;
+            this._index = index;
+        }
+    }
+    
+    internal int _size;
+    internal List<WrappedEntity> _entities;
+    internal SparseArray[] _components;  // Blocking Collections
+    internal int[] _lookupArray; // ComponentId to Array index
+
+    public SparseSet(int capacity = 64)
+    {
+        _entities = new List<WrappedEntity>();
+        _components = new SparseArray[ComponentRegistry.Size];
+        _lookupArray = new int[ComponentRegistry.Size];
+    }
+
+    /// <summary>
+    /// Creates an entity inside this sparset. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Create(in Entity entity)
+    {
+        var id = _size;
+        _entities.Add(new WrappedEntity(entity, id));
+        _size++;
+        return id;
+    }
+
+    /// <summary>
+    /// Sets a component for an index. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(int index, in T component)
+    {
+        var id = ComponentMeta<T>.Id;
+        if (id >= _lookupArray.Length)
+            _lookupArray = new int[ComponentRegistry.Size];
+        
+        var arrayIndex = _lookupArray[id];
+        
+        // Check wether array exists, if not... create
+        if (_components.Length <= arrayIndex)
+        {
+            Array.Resize(ref _components, arrayIndex+1);
+            _components[arrayIndex] = new SparseArray(typeof(T));
+        }
+            
+        var array = _components[arrayIndex];
+        if(!array.Has(index)) array.Add(index);
+        array.Set(index, in component);
+    }
+
+    
+    /// <summary>
+    /// Returns whether this index has a certain component or not. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Has<T>(int index)
+    {
+        var id = ComponentMeta<T>.Id;
+        var arrayIndex = _lookupArray[id];
+        var array = _components[arrayIndex];
+        return array.Has(index);
+    }
+
+    /// <summary>
+    /// Returns a component for the index. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T Get<T>(int index)
+    {
+        var id = ComponentMeta<T>.Id;
+        var arrayIndex = _lookupArray[id];
+        var array = _components[arrayIndex];
+        return array.Get<T>(index);
+    }
+
+    /// <summary>
+    /// Disposes this set. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        _size = 0;
+        _entities.Clear();
+        foreach (var sparset in _components)
+            sparset.Dispose();
+    }
+}
+
+/// <summary>
+/// A buffer which stores modification requests of existing entities. 
+/// </summary>
+public struct ModificationBuffer : IDisposable
+{
+    
+    /// <summary>
+    /// Represents a modificated entity, basically a real world entity which got a newly reassigned id. 
+    /// </summary>
+    public readonly ref struct ModificatedEntity
+    {
+        internal readonly int _index;
+        internal ModificatedEntity(int index)
+        {
+            _index = index;
+        }
+    }
+    
+    internal World _world;
+    internal SparseSet _sparseSet;
+    internal ConcurrentDictionary<Entity, List<Type>> _adds;
+    internal ConcurrentDictionary<Entity, List<Type>> _removes;
+
+    internal ModificationBuffer(World world, int capacity = 64)
+    {
+        _world = world;
+        _sparseSet = new SparseSet(capacity);
+    }
+
+    /// <summary>
+    /// Modifies an existing entity and returns its wrapped form to operate on.
+    /// </summary>
+    /// <param name="existingEntity"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ModificatedEntity Modify<T>(in Entity existingEntity)
+    {
+        var index = _sparseSet.Create(existingEntity);
+        return new ModificatedEntity(index);
+    }
+    
+    /// <summary>
+    /// Sets an component for a wrapped entity. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(in ModificatedEntity entity, in T component)
+    {
+        _sparseSet.Set(entity._index, component);
+    }
+
+    /// <summary>
+    /// Adds a component for a wrapped entity. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add<T>(in Entity entity)
+    {
+        if (!_adds.TryGetValue(entity, out var adds))
+        {
+            adds = new List<Type>(8);
+            _adds[entity] = adds;
+        }
+        adds.Add(typeof(T));
+    }
+
+    /// <summary>
+    /// Removes an component for a wrapped entity. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Remove<T>(in Entity entity)
+    {
+        if (!_removes.TryGetValue(entity, out var removes))
+        {
+            removes = new List<Type>(8);
+            _removes[entity] = removes;
+        }
+        removes.Add(typeof(T));
+    }
+
+    /// <summary>
+    /// Plays back all recorded operations. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Playback()
+    {
+        // Playback added
+        foreach (var kvp in _adds)
+        {
+            var entity = kvp.Key;
+            var addedComponents = kvp.Value;
+            _world.Add(in entity, addedComponents);
+        }
+        
+        // Playback removed
+        foreach (var kvp in _removes)
+        {
+            var entity = kvp.Key;
+            var removedComponents = kvp.Value;
+            _world.Remove(in entity, removedComponents);
+        }
+        
+        // Loop over all sparset entities
+        for (var index = 0; index < _sparseSet._size; index++)
+        {
+            // Get wrapped entity
+            var wrappedEntity = _sparseSet._entities[index];
+            ref readonly var entity = ref wrappedEntity._entity;
+            ref readonly var id = ref wrappedEntity._index;
+            
+            // Get entity chunk
+            ref readonly var chunk = ref _world.GetChunk(in entity);
+            var chunkIndex = chunk.EntityIdToIndex[entity.EntityId];
+            
+            // Loop over all sparset component arrays and if our entity is in one, copy the set component to its chunk 
+            for (var i = 0; i < _sparseSet._components.Length; i++)
+            {
+                var sparseArray = _sparseSet._components[index];
+                if(!sparseArray.Has(id)) continue;
+
+                var chunkArray = chunk.GetArray(sparseArray._type);
+                Array.Copy(sparseArray._components, id, chunkArray, chunkIndex, 1);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _sparseSet.Dispose();
+        _adds.Clear();
+        _removes.Clear();
+    }
+}

--- a/Arch/Core/CommandBuffer/ModificationBuffer.cs
+++ b/Arch/Core/CommandBuffer/ModificationBuffer.cs
@@ -159,7 +159,7 @@ internal class SparseSet : IDisposable
 
         _usedSize = 0;
         _used = Array.Empty<int>();
-        _components = new SparseArray[ComponentRegistry.Size];
+        _components = Array.Empty<SparseArray>();
     }
 
     /// <summary>
@@ -205,7 +205,7 @@ internal class SparseSet : IDisposable
 
         // Add and set to sparsearray
         var array = _components[id];
-        lock (array._type) if (!array.Has(index)) array.Add(index);
+        lock (array) { if (!array.Has(index)) array.Add(index); }
         array.Set(index, in component);
     }
 

--- a/Arch/Core/CommandBuffer/StructuralBuffer.cs
+++ b/Arch/Core/CommandBuffer/StructuralBuffer.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Arch.Core.CommandBuffer;
+
+public struct StructuralBuffer : IDisposable
+{
+
+    internal World _world;
+    internal ConcurrentDictionary<Entity, List<Type>> _adds;
+    internal ConcurrentDictionary<Entity, List<Type>> _removes;
+
+    public StructuralBuffer(World world)
+    {
+        _world = world;
+        _adds = new ConcurrentDictionary<Entity, List<Type>>();
+        _removes = new ConcurrentDictionary<Entity, List<Type>>();
+    }
+    
+    /// <summary>
+    /// Adds a component for a wrapped entity. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add<T>(in Entity entity)
+    {
+        if (!_adds.TryGetValue(entity, out var adds))
+        {
+            adds = new List<Type>(8);
+            _adds[entity] = adds;
+        }
+        adds.Add(typeof(T));
+    }
+
+    /// <summary>
+    /// Removes an component for a wrapped entity. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Remove<T>(in Entity entity)
+    {
+        if (!_removes.TryGetValue(entity, out var removes))
+        {
+            removes = new List<Type>(8);
+            _removes[entity] = removes;
+        }
+        removes.Add(typeof(T));
+    }
+    
+    /// <summary>
+    /// Plays back all recorded operations. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Playback()
+    {
+        // Playback added
+        foreach (var kvp in _adds)
+        {
+            var entity = kvp.Key;
+            var addedComponents = kvp.Value;
+            _world.Add(in entity, addedComponents);
+        }
+        
+        // Playback removed
+        foreach (var kvp in _removes)
+        {
+            var entity = kvp.Key;
+            var removedComponents = kvp.Value;
+            _world.Remove(in entity, removedComponents);
+        }
+        
+        Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        _adds.Clear();
+        _removes.Clear();
+    }
+}

--- a/Arch/Core/CommandBuffer/StructuralBuffer.cs
+++ b/Arch/Core/CommandBuffer/StructuralBuffer.cs
@@ -106,7 +106,7 @@ internal class StructuralSparseSet : IDisposable
     {
         _initialCapacity = capacity;
         _entities = new List<StructuralEntity>(capacity);
-        _components = new StructuralSparseArray[ComponentRegistry.Size];
+        _components = Array.Empty<StructuralSparseArray>();
     }
 
     /// <summary>
@@ -152,7 +152,7 @@ internal class StructuralSparseSet : IDisposable
         }
 
         var array = _components[id];
-        lock(_setLock) if(!array.Has(index)) array.Add(index);
+        lock(array){ if (!array.Has(index)) array.Add(index); }
     }
 
     

--- a/Arch/Core/CommandBuffer/StructuralBuffer.cs
+++ b/Arch/Core/CommandBuffer/StructuralBuffer.cs
@@ -1,22 +1,221 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Arch.Core.Utils;
+using Collections.Pooled;
 
 namespace Arch.Core.CommandBuffer;
 
+
+/// <summary>
+/// Represents an entity, combined to a internal sparset index id for fast lookups.
+/// </summary>
+public readonly struct WrappedEntity
+{
+    internal readonly Entity _entity;
+    internal readonly int _index;
+
+    public WrappedEntity(Entity entity, int index)
+    {
+        _entity = entity;
+        this._index = index;
+    }
+}
+
+/// <summary>
+/// A sparse array, an alternative to archetypes.
+/// </summary>
+internal class StructuralSparseArray : IDisposable
+{
+
+    internal Type _type;
+    internal int _size;
+    internal int[] _entities;
+
+    public StructuralSparseArray(Type type, int capacity = 64)
+    {
+        _type = type;
+        _size = 0;
+        _entities = new int[capacity];
+    }
+
+    /// <summary>
+    /// Adds an entity to this sparse array.
+    /// </summary>
+    /// <param name="index"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(int index)
+    {
+        // Resize entities
+        if (index >= _entities.Length)
+        {
+            Array.Resize(ref _entities, index+1);
+            Array.Fill(_entities, -1, _size, index);
+        }
+
+        _entities[index] = _size;
+        _size++;
+    }
+    
+    /// <summary>
+    /// Returns true if this sparsearray contains an entity. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Has(int index)
+    {
+        return index < _entities.Length && _entities[index] != -1;
+    }
+    
+    /// <summary>
+    /// Disposes this array. 
+    /// </summary>
+    public void Dispose()
+    {
+        _size = 0;
+    }
+}
+
+/// <summary>
+/// A sparset which is an alternative to an archetype. Has some advantages, for example less copy around stuff and easier archetype changes. 
+/// </summary>
+internal class StructuralSparseSet : IDisposable
+{
+
+    internal int _initialCapacity;
+    
+    internal int _size;                            // Amount of entities
+    internal List<WrappedEntity> _entities;
+    
+    internal int[] _used;                          // Stores all used component indexes in a tightly packed array [5,1,10]
+    internal int _usedSize;                        // Amount of different components
+    internal StructuralSparseArray[] _components;  // The components as a sparset so we can easily acess them via component ids
+
+    public StructuralSparseSet(int capacity = 64)
+    {
+        _initialCapacity = capacity;
+        _entities = new List<WrappedEntity>(capacity);
+        _components = new StructuralSparseArray[ComponentRegistry.Size];
+    }
+
+    /// <summary>
+    /// Creates an entity inside this sparset. 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Create(in Entity entity)
+    {
+        var id = _size;
+        _entities.Add(new WrappedEntity(entity, id));
+        _size++;
+        return id;
+    }
+
+    /// <summary>
+    /// Sets a component for an index. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <param name="component"></param>
+    /// <typeparam name="T"></typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(int index)
+    {
+        var id = ComponentMeta<T>.Id;
+        if (id >= _components.Length)
+        {
+            Array.Resize(ref _used, _usedSize+1);
+            Array.Resize(ref _components, id+1);
+            
+            _components[id] = new StructuralSparseArray(typeof(T));
+            _used[_usedSize] = id;
+            _usedSize++;
+        }
+        
+        var array = _components[id];
+        if(!array.Has(index)) array.Add(index);
+    }
+
+    
+    /// <summary>
+    /// Returns whether this index has a certain component or not. 
+    /// </summary>
+    /// <param name="index"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Has<T>(int index)
+    {
+        var id = ComponentMeta<T>.Id;
+        var array = _components[id];
+        return array.Has(index);
+    }
+    
+    /// <summary>
+    /// Disposes this set. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        _size = 0;
+        _entities.Clear();
+        foreach (var sparset in _components)
+            sparset?.Dispose();
+    }
+}
+
+/// <summary>
+/// A buffer to buffer structural changes for entities.
+/// </summary>
 public struct StructuralBuffer : IDisposable
 {
 
     internal World _world;
-    internal ConcurrentDictionary<Entity, List<Type>> _adds;
-    internal ConcurrentDictionary<Entity, List<Type>> _removes;
+    
+    internal StructuralSparseSet _adds;
+    internal StructuralSparseSet _removes;
+    
+    internal PooledList<Type> _addTypes;
+    internal PooledList<Type> _removeTypes;
 
-    public StructuralBuffer(World world)
+    /// <summary>
+    /// Creates a structural buffer.
+    /// </summary>
+    /// <param name="world">The world this buffer playbacks to.</param>
+    /// <param name="capacity">The initial capacity, grows if it was filled.</param>
+    public StructuralBuffer(World world, int capacity = 64)
     {
         _world = world;
-        _adds = new ConcurrentDictionary<Entity, List<Type>>();
-        _removes = new ConcurrentDictionary<Entity, List<Type>>();
+        _adds = new StructuralSparseSet(capacity);
+        _removes = new StructuralSparseSet(capacity);
+        _addTypes = new PooledList<Type>(8);
+        _removeTypes = new PooledList<Type>(8);
+    }
+
+    /// <summary>
+    /// Creates a add operation for an passed existing entity.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns>A wrapped entity which can be used in further add operations. </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WrappedEntity BatchAdd(in Entity entity)
+    {
+        var id = _adds.Create(in entity);
+        return new WrappedEntity(entity, id);
+    }
+    
+    /// <summary>
+    /// Creates a remove operation for an passed existing entity.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns>A wrapped entity which can be used in further remove operations.</returns>
+    public WrappedEntity BatchRemove(in Entity entity)
+    {
+        var id = _removes.Create(in entity);
+        return new WrappedEntity(entity, id);
     }
     
     /// <summary>
@@ -25,14 +224,9 @@ public struct StructuralBuffer : IDisposable
     /// <param name="entity"></param>
     /// <typeparam name="T"></typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in Entity entity)
+    public void Add<T>(in WrappedEntity entity)
     {
-        if (!_adds.TryGetValue(entity, out var adds))
-        {
-            adds = new List<Type>(8);
-            _adds[entity] = adds;
-        }
-        adds.Add(typeof(T));
+        _adds.Set<T>(entity._index);
     }
 
     /// <summary>
@@ -41,14 +235,9 @@ public struct StructuralBuffer : IDisposable
     /// <param name="entity"></param>
     /// <typeparam name="T"></typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Remove<T>(in Entity entity)
+    public void Remove<T>(in WrappedEntity entity)
     {
-        if (!_removes.TryGetValue(entity, out var removes))
-        {
-            removes = new List<Type>(8);
-            _removes[entity] = removes;
-        }
-        removes.Add(typeof(T));
+        _removes.Set<T>(entity._index);
     }
     
     /// <summary>
@@ -57,29 +246,46 @@ public struct StructuralBuffer : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Playback()
     {
-        // Playback added
-        foreach (var kvp in _adds)
+        // Playback adds
+        for (var index = 0; index < _adds._size; index++)
         {
-            var entity = kvp.Key;
-            var addedComponents = kvp.Value;
-            _world.Add(in entity, addedComponents);
+            var wrappedEntity = _adds._entities[index];
+            for (var i = 0; i < _adds._usedSize; i++)
+            {
+                ref var usedIndex = ref _adds._used[i];
+                ref var sparseSet = ref _adds._components[usedIndex];
+                if(!sparseSet.Has(wrappedEntity._index)) continue;
+
+                _addTypes.Add(sparseSet._type);
+            }
+            _world.Add(in wrappedEntity._entity, (IList<Type>)_addTypes);
+            _addTypes.Clear();
         }
         
-        // Playback removed
-        foreach (var kvp in _removes)
+        // Playback removes 
+        for (var index = 0; index < _removes._size; index++)
         {
-            var entity = kvp.Key;
-            var removedComponents = kvp.Value;
-            _world.Remove(in entity, removedComponents);
+            var wrappedEntity = _removes._entities[index];
+            for (var i = 0; i < _removes._usedSize; i++)
+            {
+                ref var usedIndex = ref _removes._used[i];
+                ref var sparseSet = ref _removes._components[usedIndex];
+                if(!sparseSet.Has(wrappedEntity._index)) continue;
+
+                _removeTypes.Add(sparseSet._type);
+            }
+            _world.Remove(in wrappedEntity._entity, _removeTypes);
+            _removeTypes.Clear();
         }
-        
         Dispose();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
-        _adds.Clear();
-        _removes.Clear();
+        _adds.Dispose();
+        _removes.Dispose();
+        _addTypes.Clear();
+        _removeTypes.Clear();
     }
 }

--- a/Arch/Core/Enumerators.cs
+++ b/Arch/Core/Enumerators.cs
@@ -220,7 +220,7 @@ public ref struct RangeEnumerator
         if (i <= 0) return _perJob;
         if (i == _jobs - 1)
         {
-            var amount = (int)Math.Ceiling((float)(_size % _jobs));
+            var amount = (int)Math.Ceiling((float)(_size % _jobs))+1;
             return amount > 0 ? amount : 1;
         }
         return _perJob;

--- a/Arch/Core/Extensions/ArrayExtensions.cs
+++ b/Arch/Core/Extensions/ArrayExtensions.cs
@@ -33,6 +33,29 @@ public static class ArrayExtensions
     }
     
     /// <summary>
+    /// Adds an element to an array and basically copies it. 
+    /// </summary>
+    /// <param name="target">The target array</param>
+    /// <param name="item">The new item</param>
+    /// <typeparam name="T">The types</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T[] Add<T>(this T[] target, List<T> items)
+    {
+        
+        if (target == null)
+            return null;
+        
+        var result = new T[target.Length + items.Count];
+        target.CopyTo(result, 0);
+
+        for (var index = 0; index < items.Count; index++)
+            result[target.Length+index] = items[index];
+        
+        return result;
+    }
+    
+    /// <summary>
     /// Removes an element to an array and shifts the other values.
     /// </summary>
     /// <param name="target">The target array</param>
@@ -47,6 +70,39 @@ public static class ArrayExtensions
             return null;
         
         var result = new T[target.Length - items.Length];
+        var targetSpan = target.AsSpan();
+        var resultSpan = result.AsSpan();
+        
+        var offset = 0;
+        for (var index = 0; index < targetSpan.Length; index++)
+        {
+            ref var currentItem = ref targetSpan[index];
+            if (items.Contains(currentItem))
+            {
+                offset++;
+                continue;
+            }
+            resultSpan[index - offset] = currentItem;
+        }
+        
+        return result;
+    }
+    
+    /// <summary>
+    /// Removes an element to an array and shifts the other values.
+    /// </summary>
+    /// <param name="target">The target array</param>
+    /// <param name="item">The new item</param>
+    /// <typeparam name="T">The types</typeparam>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T[] Remove<T>(this T[] target, List<T> items) 
+    {
+        
+        if (target == null)
+            return null;
+        
+        var result = new T[target.Length - items.Count];
         var targetSpan = target.AsSpan();
         var resultSpan = result.AsSpan();
         

--- a/Arch/Core/Extensions/ArrayExtensions.cs
+++ b/Arch/Core/Extensions/ArrayExtensions.cs
@@ -40,7 +40,7 @@ public static class ArrayExtensions
     /// <typeparam name="T">The types</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T[] Add<T>(this T[] target, List<T> items)
+    public static T[] Add<T>(this T[] target, IList<T> items)
     {
         
         if (target == null)
@@ -96,7 +96,7 @@ public static class ArrayExtensions
     /// <typeparam name="T">The types</typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T[] Remove<T>(this T[] target, List<T> items) 
+    public static T[] Remove<T>(this T[] target, IList<T> items) 
     {
         
         if (target == null)

--- a/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/Arch/Core/Utils/CompileTimeStatics.cs
@@ -41,10 +41,10 @@ public static class ComponentRegistry
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Add(Type type)
     {
-        if (Has(type)) return Get(type);
+        if (TryGet(type, out var id)) return id;
 
         // Register and assign component id
-        var id = Size;
+        id = Size;
         TypeIds.Add(type, id);
 
         Size++;
@@ -79,9 +79,9 @@ public static class ComponentRegistry
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int Get<T>()
+    public static bool TryGet<T>(out int index)
     {
-        return Get(typeof(T));
+        return TryGet(typeof(T), out index);
     }
 
     /// <summary>
@@ -90,9 +90,9 @@ public static class ComponentRegistry
     /// <param name="type"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int Get(Type type)
+    public static bool TryGet(Type type, out int id)
     {
-        return TypeIds[type];
+        return TypeIds.TryGetValue(type, out id);
     }
 }
 
@@ -119,10 +119,16 @@ public static class ComponentMeta<T>
 /// <typeparam name="T"></typeparam>
 public static class ComponentMeta
 {
+    
+    /// <summary>
+    /// Returns the components id, based on its type. 
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Id(Type type)
     {
-        return ComponentRegistry.Has(type) ? ComponentRegistry.Get(type) : ComponentRegistry.Add(type);
+        return !ComponentRegistry.TryGet(type, out var index) ? ComponentRegistry.Add(type) : index;
     }
     
     /// <summary>
@@ -218,6 +224,7 @@ public static class JobMeta<T> where T : class, new()
     }
 }
 
+// TODO : Based on the hash of each Group we can easily Map a Group<T,T,T..> to another Group... Like Group<int, byte> to Group<byte,int> since they are the same based on the hash actually. 
 public static class Group
 {
     internal static int Id;

--- a/Arch/Core/Utils/LookupArray.cs
+++ b/Arch/Core/Utils/LookupArray.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Arch.Core.Utils;
+
+public class LookupArray<T>
+{
+    private int _bucketSize;
+    private T[][] _bucketArray;
+
+    public LookupArray(int bucketSize, int capacity = 64)
+    {
+        _bucketSize = bucketSize;
+        _bucketArray = new T[(int)Math.Ceiling((float)capacity/bucketSize)][];
+        
+        for (var i = 0; i < _bucketArray.Length; i++)
+            _bucketArray[i] = new T[_bucketSize];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void EnsureCapacity(int newCapacity)
+    {
+        var length = _bucketArray.Length;
+        if (newCapacity < _bucketArray.Length * _bucketSize) return;
+        
+        var buckets = (int)Math.Ceiling((float)newCapacity / _bucketSize);
+        Array.Resize(ref _bucketArray, buckets);
+
+        for (var i = length; i < _bucketArray.Length; i++)
+            _bucketArray[i] = new T[_bucketSize];
+    }
+    
+    public ref T this[int i]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref _bucketArray[(int)Math.Floor((float)i / _bucketSize)][i % _bucketSize];
+    }
+}


### PR DESCRIPTION
Final draft of the command buffer API to buffer entity changes to play them back at a desired moment.
Also adds several other small util methods, classes and even more parallel query overloads, targets #17.

```csharp
var creationBuffer = new CreationBuffer(world, 1024); <- Initial capacity, not total capacity 
world.ParallelQuery(in desc, (in Entity en) => {

   var entity = creationBuffer.Create(group); 
   entity.Set<Explosion>(...);
   entity.Set<Position>(...);
});
creationBuffer.Playback();
```
