### PR TITLE
Entity struct padding to fit 8 bytes size

### DIFF
--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -19,14 +19,16 @@ namespace Arch.Core;
 /// <summary>
 ///     Represents an entity in our world.
 /// </summary>
+[StructLayout(Layout.Sequential)]
 public readonly struct Entity : IEquatable<Entity>
 {
     // The id of this entity in the world, not in the archetype
     public readonly int EntityId;
     public readonly byte WorldId;
+    private readonly byte _pad;
     public readonly ushort Version;
 
-    public static Entity Null => new(-1, 0, 0);
+    public static readonly Entity Null = new(-1, 0, 0);
 
     internal Entity(int entityId, byte worldId, ushort version)
     {


### PR DESCRIPTION
This is an hack to set the entity 8 bytes aligned and should help in terms of performances [I didn't test tbh].
In addition the `Null` entity will be created just one time now