### PR TITLE
Entity struct as record and skipinitialization

### DIFF
--- a/Arch/Core/Utils/NetStandardHack.cs
+++ b/Arch/Core/Utils/NetStandardHack.cs
@@ -1,0 +1,6 @@
+﻿#if NETSTANDARD2_1_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+#endif

--- a/Arch/Core/Utils/NetStandardHack.cs
+++ b/Arch/Core/Utils/NetStandardHack.cs
@@ -2,5 +2,23 @@
 namespace System.Runtime.CompilerServices
 {
     internal static class IsExternalInit { }
+
+    /// <summary>
+    /// Used to indicate to the compiler that the <c>.locals init</c> flag should not be set in method headers.
+    /// </summary>
+    /// <remarks>Internal copy of the .NET 5 attribute.</remarks>
+    [AttributeUsage(
+        AttributeTargets.Module |
+        AttributeTargets.Class |
+        AttributeTargets.Struct |
+        AttributeTargets.Interface |
+        AttributeTargets.Constructor |
+        AttributeTargets.Method |
+        AttributeTargets.Property |
+        AttributeTargets.Event,
+        Inherited = false)]
+    internal sealed class SkipLocalsInitAttribute : Attribute
+    {
+    }
 }
 #endif

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -23,113 +23,23 @@ namespace Arch.Core;
 /// <summary>
 ///     Represents an entity in our world.
 /// </summary>
-public readonly struct Entity : IEquatable<Entity>
+[SkipLocalsInit]
+public readonly record struct Entity(int Id)
 {
-    // The id of this entity in the world, not in the archetype
-    public readonly int Id;
-    public static readonly Entity Null = new(-1, 0);
+    public static readonly Entity Null = new(-1);
+};
 
-    internal Entity(int id, int worldId)
-    {
-        Id = id;
-    }
-
-    public bool Equals(Entity other)
-    {
-        return Id == other.Id;
-    }
-
-    public override bool Equals(object obj)
-    {
-        return obj is Entity other && Equals(other);
-    }
-
-    public override int GetHashCode()
-    {
-        unchecked
-        {
-            // Overflow is fine, just wrap
-            var hash = 17;
-            hash = hash * 23 + Id;
-            return hash;
-        }
-    }
-
-    public static bool operator ==(Entity left, Entity right)
-    {
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(Entity left, Entity right)
-    {
-        return !left.Equals(right);
-    }
-
-    public override string ToString()
-    {
-        return $"{nameof(Id)}: {Id}";
-    }
-}
-
-#else 
+#else
 
 /// <summary>
 ///     Represents an entity in our world.
 /// </summary>
-public readonly struct Entity : IEquatable<Entity>
+[SkipLocalsInit]
+public readonly record struct Entity(int Id, int WorldId)
 {
-    // The id of this entity in the world, not in the archetype
-    public readonly int Id;
-    public readonly int WorldId;
-    
-    /// <summary>
-    /// A null entity. 
-    /// </summary>
     public static readonly Entity Null = new(-1, 0);
+};
 
-    internal Entity(int id, int worldId)
-    {
-        Id = id;
-        WorldId = worldId;
-    }
-
-    public bool Equals(Entity other)
-    {
-        return Id == other.Id && WorldId == other.WorldId;
-    }
-
-    public override bool Equals(object obj)
-    {
-        return obj is Entity other && Equals(other);
-    }
-
-    public override int GetHashCode()
-    {
-        unchecked
-        {
-            // Overflow is fine, just wrap
-            var hash = 17;
-            hash = hash * 23 + Id;
-            hash = hash * 23 + WorldId;
-            return hash;
-        }
-    }
-
-    public static bool operator ==(Entity left, Entity right)
-    {
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(Entity left, Entity right)
-    {
-        return !left.Equals(right);
-    }
-
-    public override string ToString()
-    {
-        return $"{nameof(Id)}: {Id}, {nameof(WorldId)}: {WorldId}";
-    }
-}
 #endif
 
 


### PR DESCRIPTION
The C# code is basically the same. Im not sure if you want keep current hashing code.
https://sharplab.io/#gist:b9f99b6751be707e22f86a32e436d259

Looking at the test below, the big difference in terms of cache misses is when doing `100000` iterations


### This patch
```BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.100
  [Host]   : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  ShortRun : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

|               Method |  Amount |          Mean |         Error |      StdDev | CacheMisses/Op | Allocated |
|--------------------- |-------- |--------------:|--------------:|------------:|---------------:|----------:|
|     WorldEntityQuery |   10000 |    151.816 us |    13.3004 us |   0.7290 us |            138 |         - |
| EntityExtensionQuery |   10000 |    161.559 us |    15.1074 us |   0.8281 us |            187 |         - |
|                Query |   10000 |     17.631 us |     0.1764 us |   0.0097 us |             16 |         - |
|          EntityQuery |   10000 |     19.748 us |     0.1444 us |   0.0079 us |             14 |         - |
|          StructQuery |   10000 |      7.691 us |     2.7222 us |   0.1492 us |              6 |         - |
|    StructEntityQuery |   10000 |      7.689 us |     1.6446 us |   0.0901 us |              9 |         - |
|     WorldEntityQuery |  100000 |  1,545.191 us |   298.5741 us |  16.3659 us |         68,723 |       3 B |
| EntityExtensionQuery |  100000 |  1,694.176 us |    79.9687 us |   4.3834 us |         66,291 |       3 B |
|                Query |  100000 |    157.414 us |    17.8139 us |   0.9764 us |            278 |         - |
|          EntityQuery |  100000 |    181.623 us |    53.5252 us |   2.9339 us |            867 |         - |
|          StructQuery |  100000 |     77.659 us |     1.2913 us |   0.0708 us |            113 |         - |
|    StructEntityQuery |  100000 |     78.497 us |    26.5042 us |   1.4528 us |            126 |         - |
|     WorldEntityQuery | 1000000 | 16,595.399 us | 2,045.2195 us | 112.1054 us |      1,804,032 |      44 B |
| EntityExtensionQuery | 1000000 | 18,250.400 us |   450.5178 us |  24.6944 us |      1,808,000 |      44 B |
|                Query | 1000000 |  2,442.993 us |   120.9713 us |   6.6308 us |        410,046 |       5 B |
|          EntityQuery | 1000000 |  2,436.055 us |   263.7216 us |  14.4555 us |        407,930 |       5 B |
|          StructQuery | 1000000 |  1,471.004 us |   413.2545 us |  22.6519 us |        312,984 |       3 B |
|    StructEntityQuery | 1000000 |  1,453.622 us |   107.5262 us |   5.8939 us |        311,511 |       3 B |
```

### Current `master` [4b07e2f6d02a9957614d4aa1e616d0fbea9893a6]
```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.100
  [Host]   : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  ShortRun : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

|               Method |  Amount |          Mean |       Error |     StdDev | CacheMisses/Op | Allocated |
|--------------------- |-------- |--------------:|------------:|-----------:|---------------:|----------:|
|     WorldEntityQuery |   10000 |    144.115 us |   1.7013 us |  0.0933 us |            101 |         - |
| EntityExtensionQuery |   10000 |    162.507 us | 117.6404 us |  6.4483 us |            171 |         - |
|                Query |   10000 |     17.757 us |   3.0210 us |  0.1656 us |             20 |         - |
|          EntityQuery |   10000 |     15.649 us |   3.8336 us |  0.2101 us |             15 |         - |
|          StructQuery |   10000 |      7.693 us |   3.2779 us |  0.1797 us |             11 |         - |
|    StructEntityQuery |   10000 |      7.590 us |   0.8577 us |  0.0470 us |              5 |         - |
|     WorldEntityQuery |  100000 |  1,559.392 us | 530.9845 us | 29.1051 us |         89,543 |       3 B |
| EntityExtensionQuery |  100000 |  1,681.872 us |  60.2621 us |  3.3032 us |         59,346 |       3 B |
|                Query |  100000 |    158.516 us |  34.0276 us |  1.8652 us |            551 |         - |
|          EntityQuery |  100000 |    179.057 us |  36.9755 us |  2.0268 us |            504 |         - |
|          StructQuery |  100000 |     77.814 us |   3.7778 us |  0.2071 us |            113 |         - |
|    StructEntityQuery |  100000 |     77.964 us |   9.7857 us |  0.5364 us |             91 |         - |
|     WorldEntityQuery | 1000000 | 16,590.456 us | 732.8421 us | 40.1695 us |      1,808,427 |      44 B |
| EntityExtensionQuery | 1000000 | 18,106.704 us | 842.8082 us | 46.1972 us |      1,809,408 |      44 B |
|                Query | 1000000 |  2,631.145 us |  14.8949 us |  0.8164 us |        419,103 |       5 B |
|          EntityQuery | 1000000 |  2,240.462 us | 370.4326 us | 20.3047 us |        399,245 |       5 B |
|          StructQuery | 1000000 |  1,419.161 us | 202.9416 us | 11.1239 us |        313,018 |       3 B |
|    StructEntityQuery | 1000000 |  1,399.635 us | 214.6131 us | 11.7637 us |        312,739 |       3 B |
```