### PR TITLE
Support entity creation/deletion during a query

### DIFF
--- a/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
@@ -92,7 +92,7 @@ public partial class World{{
             
             {getFirstElement}
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
                 {getComponents}
                 iForEach.Update({insertParams});
@@ -146,7 +146,7 @@ public partial class World{{
             
             {getFirstElement}
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
                 {getComponents}
                 t.Update({insertParams});
@@ -201,7 +201,7 @@ public partial class World{{
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
             {getFirstElement}
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 {getComponents}
@@ -257,7 +257,7 @@ public partial class World{{
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
             {getFirstElement}
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 {getComponents}

--- a/Arch.SourceGenerator/Queries/JobExtensions.cs
+++ b/Arch.SourceGenerator/Queries/JobExtensions.cs
@@ -31,7 +31,7 @@ public struct ForEachJob<{generics}> : IChunkJob {{
 
         {getFirstElement}
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
             {getComponents}
             ForEach({insertParams});
@@ -70,7 +70,7 @@ public struct ForEachWithEntityJob<{generics}> : IChunkJob {{
         ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
         {getFirstElement}
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
             ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
             {getComponents}
@@ -109,7 +109,7 @@ public struct IForEachJob<T,{generics}> : IChunkJob where T : struct, IForEach<{
 
         {getFirstElement}
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
             {getComponents}
             ForEach.Update({insertParams});
@@ -148,7 +148,7 @@ public struct IForEachWithEntityJob<T,{generics}> : IChunkJob where T : struct, 
         ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
         {getFirstElement}
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
             ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
             {getComponents}

--- a/Arch.SourceGenerator/Queries/QueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/QueryExtensions.cs
@@ -113,7 +113,7 @@ foreach (ref var chunk in query.GetChunkIterator()) {{
 
     {getFirstElement}
 
-    for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+    for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
         {getComponents}
         forEach({insertParams});
@@ -160,7 +160,7 @@ foreach (ref var chunk in query.GetChunkIterator()) {{
     ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
     {getFirstElement}
 
-    for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++) {{
+    for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
 
         ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
         {getComponents}

--- a/Arch/Core/Jobs/Jobs.cs
+++ b/Arch/Core/Jobs/Jobs.cs
@@ -58,7 +58,7 @@ public struct ForEachJob : IChunkJob
         var chunkSize = chunk.Size;
         ref var entityFirstElement = ref chunk.Entities.DangerousGetReference();
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
         {
             ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
             ForEach(in entity);
@@ -79,7 +79,7 @@ public struct IForEachJob<T> : IChunkJob where T : IForEach
         var chunkSize = chunk.Size;
         ref var entityFirstElement = ref chunk.Entities.DangerousGetReference();
 
-        for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+        for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
         {
             ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
             ForEach.Update(in entity);

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -414,7 +414,7 @@ public partial class World
             var chunkSize = chunk.Size;
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
             {
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 list.Add(entity);
@@ -539,7 +539,7 @@ public partial class World
             var chunkSize = chunk.Size;
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
             {
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 forEntity(entity);
@@ -562,7 +562,7 @@ public partial class World
             var chunkSize = chunk.Size;
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
             {
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 t.Update(in entity);
@@ -584,7 +584,7 @@ public partial class World
             var chunkSize = chunk.Size;
             ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
 
-            for (var entityIndex = 0; entityIndex < chunkSize; entityIndex++)
+            for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex)
             {
                 ref readonly var entity = ref Unsafe.Add(ref entityFirstElement, entityIndex);
                 iForEach.Update(in entity);

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -354,8 +354,12 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Destroy(in Entity entity)
     {
+        // we need to cache the ID because it will get overrided
+        // during the next operations
+        var id = entity.Id;
+
         // Remove from archetype
-        var entityInfo = EntityInfo[entity.Id];
+        var entityInfo = EntityInfo[id];
         var archetype = entityInfo.Archetype;
         var destroyedChunk = archetype.Remove(ref entityInfo.Slot, out var movedEntityId);
 
@@ -363,10 +367,10 @@ public partial class World
         var movedEntityInfo = EntityInfo[movedEntityId];
         movedEntityInfo.Slot = entityInfo.Slot;
         EntityInfo[movedEntityId] = movedEntityInfo;
-        
+
         // Recycle id && Remove mapping
-        RecycledIds.Enqueue(entity.Id);
-        EntityInfo.Remove(entity.Id);
+        RecycledIds.Enqueue(id);
+        EntityInfo.Remove(id);
 
         // Resizing and releasing memory 
         if (destroyedChunk)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A highperformance C# based Archetype & Chunks [Entity Component System](https://
 
 Download the [package](https://github.com/genaray/Arch/packages/1697222) and get started today ! 
 ```console
-dotnet add PROJECT package Arch --version 1.0.17
+dotnet add PROJECT package Arch --version 1.1.0
 ```
 
 # Code Sample


### PR DESCRIPTION
This solve https://github.com/genaray/Arch/issues/13
The problem was with the line:
`var destroyedChunk = archetype.Remove(ref entityInfo.Slot, out var movedEntityId);`
which moves the last entity to the destroyed entity index.
 When this happens `in Entity` [which is translated into `ref readonly Entity`] changes the reference to the moved entity, so Arch will recycle a valid ID.

Tested with the code below [and some other variations]
```csharp
        struct P { }

        var world = World.Create();
        var query = new QueryDescription()
        {
            All = new Core.Utils.ComponentType[] { typeof(P) },
        };

        for (int i = 0; i < 100; ++i)
            world.Create<P>();

        while (true)
        {
            world.Query(in query, (in Entity e) =>
            {
                world.Destroy(in e);
                var ee = world.Create<P>();
            });
        }
```