### PR TITLE
Remove reflection

### DIFF
--- a/Arch.Samples/Components.cs
+++ b/Arch.Samples/Components.cs
@@ -24,6 +24,5 @@ public struct Velocity
 /// </summary>
 public struct Sprite
 {
-    public Texture2D Texture2D;
     public Color Color;
 }

--- a/Arch.Samples/Game.cs
+++ b/Arch.Samples/Game.cs
@@ -32,6 +32,11 @@ public class Game : Microsoft.Xna.Framework.Game
     {
         _graphics = new GraphicsDeviceManager(this);
         Content.RootDirectory = "Content";
+        this.IsFixedTimeStep = false;
+        _graphics.SynchronizeWithVerticalRetrace = false;
+        this.IsMouseVisible = true;
+        this.InactiveSleepTime = TimeSpan.Zero;
+        this.Window.Title = "No reflection";
     }
     
     protected override void Initialize()
@@ -61,7 +66,7 @@ public class Game : Microsoft.Xna.Framework.Game
         _jobScheduler = new("SampleWorkerThreads");
         _movementSystem = new MovementSystem(_world, GraphicsDevice.Viewport.Bounds);
         _colorSystem = new ColorSystem(_world);
-        _drawSystem = new DrawSystem(_world, _spriteBatch);
+        _drawSystem = new DrawSystem(_world, _spriteBatch, _texture2D);
 
         // Spawn in entities with position, velocity and sprite
         for (var index = 0; index < 1000; index++)
@@ -69,7 +74,7 @@ public class Game : Microsoft.Xna.Framework.Game
             _world.Create(
                 new Position{ Vec2 = _random.NextVector2(GraphicsDevice.Viewport.Bounds) }, 
                 new Velocity{ Vec2 = _random.NextVector2(-0.25f,0.25f) }, 
-                new Sprite{ Texture2D = _texture2D, Color = _random.NextColor() }
+                new Sprite{ /*Texture2D = _texture2D,*/ Color = _random.NextColor() }
             );
         }
     }
@@ -93,7 +98,7 @@ public class Game : Microsoft.Xna.Framework.Game
     {
         _graphics.GraphicsDevice.Clear(Color.CornflowerBlue);
         _drawSystem.Update(in gameTime);
-        Console.WriteLine($"FPS : {(1 / gameTime.ElapsedGameTime.TotalSeconds)}");
+        //Console.WriteLine($"FPS : {(1 / gameTime.ElapsedGameTime.TotalSeconds)}");
         base.Draw(gameTime);
     }
 

--- a/Arch.Samples/Systems.cs
+++ b/Arch.Samples/Systems.cs
@@ -133,7 +133,9 @@ public class DrawSystem : SystemBase<GameTime>
 {
 
     private readonly SpriteBatch _batch;
-    public DrawSystem(World world, SpriteBatch batch) : base(world) { _batch = batch;}
+    private readonly Texture2D _texture;
+
+    public DrawSystem(World world, SpriteBatch batch, Texture2D texture) : base(world) { _batch = batch; _texture = texture; }
 
     /// <summary>
     /// Targets all entities with a position and sprite
@@ -161,7 +163,7 @@ public class DrawSystem : SystemBase<GameTime>
                 // Get refs to position and sprite.
                 ref var position = ref positions[index];
                 ref var sprite = ref sprites[index];
-                _batch.Draw(sprite.Texture2D, position.Vec2, sprite.Color);  // Draw
+                _batch.Draw(_texture, position.Vec2, sprite.Color);  // Draw
             }
         }
         

--- a/Arch.SourceGenerator/Fundamentals/CreateExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/CreateExtensions.cs
@@ -19,10 +19,11 @@ public static class CreateExtensions
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
         var parameters = new StringBuilder().GenericInDefaultParams(amount);
         var inParameters = new StringBuilder().InsertGenericInParams(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public Entity Create<{generics}>({parameters})
+public Entity Create<{generics}>({parameters}) {whereT}
 {{
     
     var types = Group<{generics}>.Types;

--- a/Arch.SourceGenerator/Fundamentals/GetExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/GetExtensions.cs
@@ -34,10 +34,12 @@ public static class GetExtensions
         var assignRefs = new StringBuilder();
         for (var index = 0; index <= amount; index++)
             assignRefs.AppendLine($"t{index} = ref t{index}Component;");
-        
+
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template = $@"
-public ref struct References<{generics}>
+public ref struct References<{generics}> {whereT}
 {{
 
 #if NETSTANDARD2_1 || NET6_0
@@ -79,11 +81,13 @@ public ref struct References<{generics}>
         var gets = new StringBuilder();
         for (var index = 0; index <= amount; index++)
             gets.AppendLine($"ref var t{index}Component = ref t{index}Array[index];");
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
 [Pure]
-public References<{generics}> Get<{generics}>(scoped in int index)
+public References<{generics}> Get<{generics}>(scoped in int index) {whereT}
 {{
     {getArrays}
     {gets}
@@ -106,9 +110,13 @@ public References<{generics}> Get<{generics}>(scoped in int index)
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-internal unsafe References<{generics}> Get<{generics}>(scoped ref Slot slot)
+internal unsafe References<{generics}> Get<{generics}>(scoped ref Slot slot) {whereT}
 {{
     ref var chunk = ref GetChunk(slot.ChunkIndex);
     return chunk.Get<{generics}>(slot.Index);
@@ -130,9 +138,13 @@ internal unsafe References<{generics}> Get<{generics}>(scoped ref Slot slot)
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public References<{generics}> Get<{generics}>(in Entity entity)
+public References<{generics}> Get<{generics}>(in Entity entity) {whereT}
 {{
     var entityInfo = EntityInfo[entity.Id];
     var archetype = entityInfo.Archetype;
@@ -155,10 +167,13 @@ public References<{generics}> Get<{generics}>(in Entity entity)
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static References<{generics}> Get<{generics}>(this in Entity entity)
+public static References<{generics}> Get<{generics}>(this in Entity entity) {whereT}
 {{
     var world = World.Worlds[entity.WorldId];
     return world.Get<{generics}>(entity);

--- a/Arch.SourceGenerator/Fundamentals/GroupExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/GroupExtensions.cs
@@ -21,8 +21,10 @@ public static class GroupExtensions
         for (var index = 0; index <= amount; index++)
             types.Append($"Component<T{index}>.ComponentType,");
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
-public static class Group<{generics}>
+public static class Group<{generics}> {whereT}
 {{
     internal static readonly int Id;
     internal static readonly ComponentType[] Types;

--- a/Arch.SourceGenerator/Fundamentals/HasExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/HasExtensions.cs
@@ -29,11 +29,13 @@ public static class HasExtensions
         var ifs = new StringBuilder();
         for (var index = 0; index <= amount; index++)
             ifs.AppendLine($"if (ComponentIdToArrayIndex[t{index}ComponentId] != 1) return false;");
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
 [Pure]
-public bool Has<{generics}>()
+public bool Has<{generics}>() {whereT}
 {{
     {getIds}
     {boundChecks}
@@ -66,10 +68,12 @@ public bool Has<{generics}>()
         for (var index = 0; index <= amount; index++)
             isSet.AppendLine($"BitSet.IsSet(t{index}ComponentId) &&");
         isSet.Length -= 4;
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public bool Has<{generics}>()
+public bool Has<{generics}>() {whereT}
 {{ 
     {getIds}
     return {isSet};
@@ -92,9 +96,11 @@ public bool Has<{generics}>()
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public bool Has<{generics}>(in Entity entity)
+public bool Has<{generics}>(in Entity entity) {whereT}
 {{
     var archetype = EntityInfo[entity.Id].Archetype;
     return archetype.Has<{generics}>();
@@ -116,10 +122,11 @@ public bool Has<{generics}>(in Entity entity)
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static bool Has<{generics}>(this in Entity entity)
+public static bool Has<{generics}>(this in Entity entity) {whereT}
 {{
     var world = World.Worlds[entity.WorldId];
     return world.Has<{generics}>(in entity);

--- a/Arch.SourceGenerator/Fundamentals/SetExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/SetExtensions.cs
@@ -26,9 +26,11 @@ public static class SetExtensions
         for (var index = 0; index <= amount; index++)
             sets.AppendLine($"t{index}Array[index] = t{index}Component;");
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Set<{generics}>(in int index, {parameters})
+public void Set<{generics}>(in int index, {parameters}) {whereT}
 {{
     {arrays}
     {sets}
@@ -52,10 +54,12 @@ public void Set<{generics}>(in int index, {parameters})
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
         var parameters = new StringBuilder().GenericInParams(amount);
         var insertParameters = new StringBuilder().InsertGenericInParams(amount);
-            
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-internal void Set<{generics}>(ref Slot slot, {parameters})
+internal void Set<{generics}>(ref Slot slot, {parameters}) {whereT}
 {{
     ref var chunk = ref GetChunk(slot.ChunkIndex);
     chunk.Set<{generics}>(slot.Index, {insertParameters});
@@ -80,9 +84,11 @@ internal void Set<{generics}>(ref Slot slot, {parameters})
         var parameters = new StringBuilder().GenericInParams(amount);
         var insertParams = new StringBuilder().InsertGenericInParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Set<{generics}>(in Entity entity, {parameters})
+public void Set<{generics}>(in Entity entity, {parameters}) {whereT}
 {{
     var entityInfo = EntityInfo[entity.Id];
     var archetype = entityInfo.Archetype;
@@ -108,9 +114,11 @@ public void Set<{generics}>(in Entity entity, {parameters})
         var parameters = new StringBuilder().GenericInParams(amount);
         var insertParams = new StringBuilder().InsertGenericInParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static void Set<{generics}>(this in Entity entity, {parameters})
+public static void Set<{generics}>(this in Entity entity, {parameters}) {whereT}
 {{
     var world = World.Worlds[entity.WorldId];
     world.Set<{generics}>(in entity, {insertParams});

--- a/Arch.SourceGenerator/Fundamentals/StructuralChangesExtensions.cs
+++ b/Arch.SourceGenerator/Fundamentals/StructuralChangesExtensions.cs
@@ -28,10 +28,13 @@ public static class StructuralChangesExtensions
         for (var index = 0; index <= amount; index++)
             types.AppendLine($"typeof(T{index}),");
         types.Length -= 3;
-        
+
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Add<{generics}>(in Entity entity, {parameters})
+public void Add<{generics}>(in Entity entity, {parameters}) {whereT}
 {{
     var oldArchetype = EntityInfo[entity.Id].Archetype;
 
@@ -72,10 +75,12 @@ public void Add<{generics}>(in Entity entity, {parameters})
         for (var index = 0; index <= amount; index++)
             types.AppendLine($"typeof(T{index}),");
         types.Length -= 3;
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Remove<{generics}>(in Entity entity)
+public void Remove<{generics}>(in Entity entity) {whereT}
 {{
     var oldArchetype = EntityInfo[entity.Id].Archetype;
 
@@ -108,10 +113,12 @@ public void Remove<{generics}>(in Entity entity)
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
         var parameters = new StringBuilder().GenericInDefaultParams(amount);
-        
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static void Add<{generics}>(this in Entity entity, {parameters})
+public static void Add<{generics}>(this in Entity entity, {parameters}) {whereT}
 {{
     var world = World.Worlds[entity.WorldId];
     world.Add<{generics}>(in entity);
@@ -133,9 +140,13 @@ public static void Add<{generics}>(this in Entity entity, {parameters})
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
+
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static void Remove<{generics}>(this in Entity entity)
+public static void Remove<{generics}>(this in Entity entity) {whereT}
 {{
     var world = World.Worlds[entity.WorldId];
     world.Remove<{generics}>(in entity);

--- a/Arch.SourceGenerator/Queries/HPParallelQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/HPParallelQueryExtensions.cs
@@ -15,10 +15,11 @@ public static class StringBuilderHpParallelQueryExtensions
     public static void AppendHpParallelQuery(this StringBuilder builder, int amount)
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}>{{
+public void HPParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}> {whereT} {{
     
     var innerJob = new IForEachJob<T,{generics}>();
     innerJob.ForEach = iForEach;
@@ -71,10 +72,11 @@ public void HPParallelQuery<T,{generics}>(in QueryDescription description, ref T
     public static void AppendHpeParallelQuery(this StringBuilder builder, int amount)
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPEParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}>{{
+public void HPEParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
     
     var innerJob = new IForEachWithEntityJob<T,{generics}>();
     innerJob.ForEach = iForEach;

--- a/Arch.SourceGenerator/Queries/HPParallelQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/HPParallelQueryExtensions.cs
@@ -14,11 +14,13 @@ public static class StringBuilderHpParallelQueryExtensions
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}>{{
+    public void HPParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}> {whereT}{{
         
         var innerJob = new IForEachJob<T,{generics}>();
         innerJob.ForEach = iForEach;
@@ -71,11 +73,13 @@ public partial class World{{
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPEParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}>{{
+    public void HPEParallelQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
         
         var innerJob = new IForEachWithEntityJob<T,{generics}>();
         innerJob.ForEach = iForEach;

--- a/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
@@ -23,6 +23,7 @@ public static class StringBuilderHpQueryExtensions
             paramSb.Append(param).Append(",");
         paramSb.Length--;
 
+
         var interfaceTemplate = $@"
 public interface {interfaceInfo.Name}<{genericSb}>{{
     
@@ -78,11 +79,13 @@ public interface {interfaceInfo.Name}<{genericSb}>{{
             var getComponents = new StringBuilder().GetGenericComponents(index);
             var insertParams = new StringBuilder().InsertGenericParams(index);
 
+            var whereT = new StringBuilder().GenericWhereStruct(index);
+
             var methodTemplate = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}>{{
+    public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}> {whereT} {{
         
         var query = Query(in description);
         foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -117,9 +120,7 @@ public partial class World{{
             for (var localIndex = 0; localIndex <= index1; localIndex++)
                 getArrays.AppendLine($"var t{localIndex}Array = chunk.GetArray<T{localIndex}>();");
 
-            var getFirstElement = new StringBuilder();
-            for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            var getFirstElement = new StringBuilder().GetFirstGenericElements(index1);
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -130,11 +131,13 @@ public partial class World{{
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEach<{generics}>{{
+    public void HPQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEach<{generics}> {whereT} {{
         
         var t = new T();
 
@@ -173,9 +176,7 @@ public partial class World{{
             for (var localIndex = 0; localIndex <= index1; localIndex++)
                 getArrays.AppendLine($"var t{localIndex}Array = chunk.GetArray<T{localIndex}>();");
 
-            var getFirstElement = new StringBuilder();
-            for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            var getFirstElement = new StringBuilder().GetFirstGenericElements(index1);
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -186,11 +187,13 @@ public partial class World{{
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}>{{
+    public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
         
         var query = Query(in description);
         foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -198,7 +201,7 @@ public partial class World{{
             var chunkSize = chunk.Size;
             {getArrays}
 
-            ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+            ref var entityFirstElement = ref chunk.Entities[0];
             {getFirstElement}
 
             for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
@@ -229,7 +232,7 @@ public partial class World{{
 
             var getFirstElement = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(t{localIndex}Array);");
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -240,11 +243,13 @@ public partial class World{{
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 public partial class World{{
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void HPEQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEachWithEntity<{generics}>{{
+    public void HPEQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
         
         var t = new T();
 
@@ -254,7 +259,7 @@ public partial class World{{
             var chunkSize = chunk.Size;
             {getArrays}
 
-            ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+            ref var entityFirstElement = ref chunk.Entities[0];
             {getFirstElement}
 
             for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{

--- a/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/HPQueryExtensions.cs
@@ -77,11 +77,12 @@ public interface {interfaceInfo.Name}<{genericSb}>{{
             var getFirstElement = new StringBuilder().GetFirstGenericElements(index);
             var getComponents = new StringBuilder().GetGenericComponents(index);
             var insertParams = new StringBuilder().InsertGenericParams(index);
+            var whereT = new StringBuilder().GenericWhereStruct(index);
 
             var methodTemplate = $@"
 
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}>{{
+public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEach<{generics}> {whereT} {{
     
     var query = Query(in description);
     foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -115,9 +116,7 @@ public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEac
             for (var localIndex = 0; localIndex <= index1; localIndex++)
                 getArrays.AppendLine($"var t{localIndex}Array = chunk.GetArray<T{localIndex}>();");
 
-            var getFirstElement = new StringBuilder();
-            for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            var getFirstElement = new StringBuilder().GetFirstGenericElements(index1);
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -128,9 +127,11 @@ public void HPQuery<T,{generics}>(in QueryDescription description, ref T iForEac
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEach<{generics}>{{
+public void HPQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEach<{generics}> {whereT} {{
     
     var t = new T();
 
@@ -170,9 +171,7 @@ public void HPQuery<T,{generics}>(in QueryDescription description) where T : str
             for (var localIndex = 0; localIndex <= index1; localIndex++)
                 getArrays.AppendLine($"var t{localIndex}Array = chunk.GetArray<T{localIndex}>();");
 
-            var getFirstElement = new StringBuilder();
-            for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            var getFirstElement = new StringBuilder().GetFirstGenericElements(index1);
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -183,9 +182,11 @@ public void HPQuery<T,{generics}>(in QueryDescription description) where T : str
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}>{{
+public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEach) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
     
     var query = Query(in description);
     foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -193,7 +194,7 @@ public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEa
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+        ref var entityFirstElement = ref MemoryMarshal.GetReference<Entity>(chunk.Entities);
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
@@ -221,9 +222,7 @@ public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEa
             for (var localIndex = 0; localIndex <= index1; localIndex++)
                 getArrays.AppendLine($"var t{localIndex}Array = chunk.GetArray<T{localIndex}>();");
 
-            var getFirstElement = new StringBuilder();
-            for (var localIndex = 0; localIndex <= index1; localIndex++)
-                getFirstElement.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            var getFirstElement = new StringBuilder().GetFirstGenericElements(index1);
 
             var getComponents = new StringBuilder();
             for (var localIndex = 0; localIndex <= index1; localIndex++)
@@ -234,9 +233,11 @@ public void HPEQuery<T,{generics}>(in QueryDescription description, ref T iForEa
                 insertParams.Append($"ref t{localIndex}Component,");
             insertParams.Length--;
 
+            var whereT = new StringBuilder().GenericWhereStruct(index1);
+
             var methodTemplate = $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void HPEQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEachWithEntity<{generics}>{{
+public void HPEQuery<T,{generics}>(in QueryDescription description) where T : struct, IForEachWithEntity<{generics}> {whereT} {{
     
     var t = new T();
 
@@ -246,7 +247,7 @@ public void HPEQuery<T,{generics}>(in QueryDescription description) where T : st
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+        ref var entityFirstElement = ref MemoryMarshal.GetReference<Entity>(chunk.Entities);
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{

--- a/Arch.SourceGenerator/Queries/JobExtensions.cs
+++ b/Arch.SourceGenerator/Queries/JobExtensions.cs
@@ -71,7 +71,7 @@ public struct ForEachWithEntityJob<{generics}> : IChunkJob {whereT} {{
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref chunk.Entities[0];
+        ref var entityFirstElement = ref MemoryMarshal.GetReference<Entity>(chunk.Entities);
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
@@ -153,7 +153,7 @@ public struct IForEachWithEntityJob<T,{generics}> : IChunkJob where T : struct, 
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref chunk.Entities[0];
+        ref var entityFirstElement = ref MemoryMarshal.GetReference<Entity>(chunk.Entities);
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{

--- a/Arch.SourceGenerator/Queries/JobExtensions.cs
+++ b/Arch.SourceGenerator/Queries/JobExtensions.cs
@@ -18,8 +18,10 @@ public static class StringBuilderChunkJobExtensions
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
-public struct ForEachJob<{generics}> : IChunkJob {{
+public struct ForEachJob<{generics}> : IChunkJob {whereT} {{
 
     public ForEach<{generics}> ForEach;
 
@@ -56,8 +58,10 @@ public struct ForEachJob<{generics}> : IChunkJob {{
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
-public struct ForEachWithEntityJob<{generics}> : IChunkJob {{
+public struct ForEachWithEntityJob<{generics}> : IChunkJob {whereT} {{
 
     public ForEachWithEntity<{generics}> ForEach;
 
@@ -67,7 +71,7 @@ public struct ForEachWithEntityJob<{generics}> : IChunkJob {{
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+        ref var entityFirstElement = ref chunk.Entities[0];
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{
@@ -96,8 +100,10 @@ public struct ForEachWithEntityJob<{generics}> : IChunkJob {{
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
-public struct IForEachJob<T,{generics}> : IChunkJob where T : struct, IForEach<{generics}>{{
+public struct IForEachJob<T,{generics}> : IChunkJob where T : struct, IForEach<{generics}> {whereT} {{
 
     public T ForEach;
 
@@ -134,8 +140,10 @@ public struct IForEachJob<T,{generics}> : IChunkJob where T : struct, IForEach<{
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
 
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = $@"
-public struct IForEachWithEntityJob<T,{generics}> : IChunkJob where T : struct, IForEachWithEntity<{generics}>{{
+public struct IForEachWithEntityJob<T,{generics}> : IChunkJob where T : struct, IForEachWithEntity<{generics}> {whereT} {{
 
     public T ForEach;
 
@@ -145,7 +153,7 @@ public struct IForEachWithEntityJob<T,{generics}> : IChunkJob where T : struct, 
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+        ref var entityFirstElement = ref chunk.Entities[0];
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{

--- a/Arch.SourceGenerator/Queries/ParallelQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/ParallelQueryExtensions.cs
@@ -16,129 +16,116 @@ public static class StringBuilderParallelQueryExtensions
         }
     }
     
-    public static void AppendParallelQuerys(this ClassBuilder builder, int amount)
+    public static StringBuilder AppendParallelQuerys(this StringBuilder builder, int amount)
     {
         for (var index = 0; index < amount; index++)
             builder.AppendParallelQuery(index);
+
+        return builder;
     }
 
-    public static void AppendParallelQuery(this ClassBuilder builder, int amount)
+    public static void AppendParallelQuery(this StringBuilder sb, int amount)
     {
-        var methodBuilder = builder.AddMethod("ParallelQuery").MakePublicMethod().WithReturnType("void");
-        methodBuilder.AddParameter("in QueryDescription", "description");
-        methodBuilder.AddAttribute("MethodImpl(MethodImplOptions.AggressiveInlining)");
+        var generics = new StringBuilder().GenericWithoutBrackets(amount).ToString();
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
-        var generics = new StringBuilder().Generic(amount).ToString();
-        methodBuilder.AddParameter($"ForEach{generics}", "forEach");
+        sb.Append($@"
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ParallelQuery<{generics}>(in QueryDescription description, ForEach<{generics}> forEach) {whereT} {{
+        
+                var innerJob = new ForEachJob<{generics}>();
+                innerJob.ForEach = forEach;
 
-        for (var index = 0; index <= amount; index++)
-            methodBuilder.AddGeneric($"T{index}");
+                var pool = JobMeta<ChunkIterationJob<ForEachJob<{generics}>>>.Pool;
+                var query = Query(in description);
+                foreach (ref var archetype in query.GetArchetypeIterator()) {{
 
-        methodBuilder.WithBody(writer =>
-        {
-            var generics = new StringBuilder().GenericWithoutBrackets(amount);
-
-            var template =
-                $@"
-var innerJob = new ForEachJob<{generics}>();
-innerJob.ForEach = forEach;
-
-var pool = JobMeta<ChunkIterationJob<ForEachJob<{generics}>>>.Pool;
-var query = Query(in description);
-foreach (ref var archetype in query.GetArchetypeIterator()) {{
-
-    var archetypeSize = archetype.Size;
-    var part = new RangePartitioner(Environment.ProcessorCount, archetypeSize);
-    foreach (var range in part) {{
+                    var archetypeSize = archetype.Size;
+                    var part = new RangePartitioner(Environment.ProcessorCount, archetypeSize);
+                    foreach (var range in part) {{
     
-        var job = pool.Get();
-        job.Start = range.Start;
-        job.Size = range.Length;
-        job.Chunks = archetype.Chunks;
-        job.Instance = innerJob;
-        JobsCache.Add(job);
-    }}
+                        var job = pool.Get();
+                        job.Start = range.Start;
+                        job.Size = range.Length;
+                        job.Chunks = archetype.Chunks;
+                        job.Instance = innerJob;
+                        JobsCache.Add(job);
+                    }}
 
-    IJob.Schedule(JobsCache, JobHandles);
-    JobScheduler.JobScheduler.Instance.Flush();
-    JobHandle.Complete(JobHandles);
-    JobHandle.Return(JobHandles);
+                    IJob.Schedule(JobsCache, JobHandles);
+                    JobScheduler.JobScheduler.Instance.Flush();
+                    JobHandle.Complete(JobHandles);
+                    JobHandle.Return(JobHandles);
 
-    // Return jobs to pool
-    for (var jobIndex = 0; jobIndex < JobsCache.Count; jobIndex++) {{
+                    // Return jobs to pool
+                    for (var jobIndex = 0; jobIndex < JobsCache.Count; jobIndex++) {{
 
-        var job = Unsafe.As<ChunkIterationJob<ForEachJob<{generics}>>>(JobsCache[jobIndex]);
-        pool.Return(job);
-    }}
+                        var job = Unsafe.As<ChunkIterationJob<ForEachJob<{generics}>>>(JobsCache[jobIndex]);
+                        pool.Return(job);
+                    }}
 
-    JobHandles.Clear();
-    JobsCache.Clear();
-}}
-";
-            writer.AppendLine(template);
-        });
+                    JobHandles.Clear();
+                    JobsCache.Clear();
+                }}
+            }}
+        
+        ");
     }
 
-    public static void AppendParallelEntityQuerys(this ClassBuilder builder, int amount)
+    public static StringBuilder AppendParallelEntityQuerys(this StringBuilder builder, int amount)
     {
         for (var index = 0; index < amount; index++)
             builder.AppendParallelEntityQuery(index);
+
+        return builder;
     }
 
-    public static void AppendParallelEntityQuery(this ClassBuilder builder, int amount)
+    public static void AppendParallelEntityQuery(this StringBuilder sb, int amount)
     {
-        var methodBuilder = builder.AddMethod("ParallelQuery").MakePublicMethod().WithReturnType("void");
-        methodBuilder.AddParameter("in QueryDescription", "description");
-        methodBuilder.AddAttribute("MethodImpl(MethodImplOptions.AggressiveInlining)");
+        var generics = new StringBuilder().GenericWithoutBrackets(amount).ToString();
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
-        var generics = new StringBuilder().Generic(amount).ToString();
-        methodBuilder.AddParameter($"ForEachWithEntity{generics}", "forEach");
+        sb.Append($@"
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ParallelQuery<{generics}>(in QueryDescription description, ForEachWithEntity<{generics}> forEach) {whereT} {{
+        
+                var innerJob = new ForEachWithEntityJob<{generics}>();
+                innerJob.ForEach = forEach;
 
-        for (var index = 0; index <= amount; index++)
-            methodBuilder.AddGeneric($"T{index}");
+                var pool = JobMeta<ChunkIterationJob<ForEachWithEntityJob<{generics}>>>.Pool;
+                var query = Query(in description);
+                foreach (ref var archetype in query.GetArchetypeIterator()) {{
 
-        methodBuilder.WithBody(writer =>
-        {
-            var generics = new StringBuilder().GenericWithoutBrackets(amount);
-
-            var template =
-                $@"
-var innerJob = new ForEachWithEntityJob<{generics}>();
-innerJob.ForEach = forEach;
-
-var pool = JobMeta<ChunkIterationJob<ForEachWithEntityJob<{generics}>>>.Pool;
-var query = Query(in description);
-foreach (ref var archetype in query.GetArchetypeIterator()) {{
-
-    var archetypeSize = archetype.Size;
-    var part = new RangePartitioner(Environment.ProcessorCount, archetypeSize);
-    foreach (var range in part) {{
+                    var archetypeSize = archetype.Size;
+                    var part = new RangePartitioner(Environment.ProcessorCount, archetypeSize);
+                    foreach (var range in part) {{
     
-        var job = pool.Get();
-        job.Start = range.Start;
-        job.Size = range.Length;
-        job.Chunks = archetype.Chunks;
-        job.Instance = innerJob;
-        JobsCache.Add(job);
-    }}
+                        var job = pool.Get();
+                        job.Start = range.Start;
+                        job.Size = range.Length;
+                        job.Chunks = archetype.Chunks;
+                        job.Instance = innerJob;
+                        JobsCache.Add(job);
+                    }}
 
-    IJob.Schedule(JobsCache, JobHandles);
-    JobScheduler.JobScheduler.Instance.Flush();
-    JobHandle.Complete(JobHandles);
-    JobHandle.Return(JobHandles);
+                    IJob.Schedule(JobsCache, JobHandles);
+                    JobScheduler.JobScheduler.Instance.Flush();
+                    JobHandle.Complete(JobHandles);
+                    JobHandle.Return(JobHandles);
 
-    // Return jobs to pool
-    for (var jobIndex = 0; jobIndex < JobsCache.Count; jobIndex++) {{
+                    // Return jobs to pool
+                    for (var jobIndex = 0; jobIndex < JobsCache.Count; jobIndex++) {{
 
-        var job = Unsafe.As<ChunkIterationJob<ForEachWithEntityJob<{generics}>>>(JobsCache[jobIndex]);
-        pool.Return(job);
-    }}
+                        var job = Unsafe.As<ChunkIterationJob<ForEachWithEntityJob<{generics}>>>(JobsCache[jobIndex]);
+                        pool.Return(job);
+                    }}
 
-    JobHandles.Clear();
-    JobsCache.Clear();
-}}
-";
-            writer.AppendLine(template);
-        });
+                    JobHandles.Clear();
+                    JobsCache.Clear();
+                }}
+            }}
+        ");
     }
 }

--- a/Arch.SourceGenerator/Queries/ParallelQueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/ParallelQueryExtensions.cs
@@ -17,10 +17,12 @@ public static class StringBuilderParallelQueryExtensions
     public static StringBuilder AppendParallelQuery(this StringBuilder sb, int amount)
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template =
             $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void ParallelQuery<{generics}>(in QueryDescription description, ForEach<{generics}> forEach){{
+public void ParallelQuery<{generics}>(in QueryDescription description, ForEach<{generics}> forEach) {whereT} {{
     var innerJob = new ForEachJob<{generics}>();
     innerJob.ForEach = forEach;
 
@@ -71,10 +73,12 @@ public void ParallelQuery<{generics}>(in QueryDescription description, ForEach<{
     public static StringBuilder AppendParallelEntityQuery(this StringBuilder sb, int amount)
     {
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template =
                 $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void ParallelQuery<{generics}>(in QueryDescription description, ForEachWithEntity<{generics}> forEach){{
+public void ParallelQuery<{generics}>(in QueryDescription description, ForEachWithEntity<{generics}> forEach) {whereT} {{
 
     var innerJob = new ForEachWithEntityJob<{generics}>();
     innerJob.ForEach = forEach;

--- a/Arch.SourceGenerator/Queries/QueryDescriptionExtensions.cs
+++ b/Arch.SourceGenerator/Queries/QueryDescriptionExtensions.cs
@@ -15,10 +15,12 @@ public static class QueryDescriptionExtensions
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
 $@"
 [UnscopedRef]
-public ref QueryDescription WithAll<{generics}>()
+public ref QueryDescription WithAll<{generics}>() {whereT}
 {{
    All = Group<{generics}>.Types;
    return ref this;
@@ -39,10 +41,12 @@ public ref QueryDescription WithAll<{generics}>()
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
             $@"
 [UnscopedRef]
-public ref QueryDescription WithAny<{generics}>()
+public ref QueryDescription WithAny<{generics}>() {whereT}
 {{
    Any = Group<{generics}>.Types;
    return ref this;
@@ -63,10 +67,12 @@ public ref QueryDescription WithAny<{generics}>()
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
             $@"
 [UnscopedRef]
-public ref QueryDescription WithNone<{generics}>()
+public ref QueryDescription WithNone<{generics}>() {whereT}
 {{
    None = Group<{generics}>.Types;
    return ref this;
@@ -87,10 +93,12 @@ public ref QueryDescription WithNone<{generics}>()
     {
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
             $@"
 [UnscopedRef]
-public ref QueryDescription WithExclusive<{generics}>()
+public ref QueryDescription WithExclusive<{generics}>() {whereT}
 {{
    Exclusive = Group<{generics}>.Types;
    return ref this;

--- a/Arch.SourceGenerator/Queries/QueryExtensions.cs
+++ b/Arch.SourceGenerator/Queries/QueryExtensions.cs
@@ -17,9 +17,11 @@ public static class StringBuilderQueryExtensions
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
         var parameters = new StringBuilder().GenericRefParams(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
 $@"
-public delegate void ForEach<{generics}>({parameters});
+public delegate void ForEach<{generics}>({parameters}) {whereT};
 ";
         sb.Append(template);
         return sb;
@@ -37,9 +39,11 @@ public delegate void ForEach<{generics}>({parameters});
 
         var generics = new StringBuilder().GenericWithoutBrackets(amount);
         var parameters = new StringBuilder().GenericRefParams(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
+
         var template = 
             $@"
-public delegate void ForEachWithEntity<{generics}>(in Entity entity, {parameters});
+public delegate void ForEachWithEntity<{generics}>(in Entity entity, {parameters}) {whereT};
 ";
         sb.Append(template);
         return sb;
@@ -60,11 +64,12 @@ public delegate void ForEachWithEntity<{generics}>(in Entity entity, {parameters
         var getFirstElement = new StringBuilder().GetFirstGenericElements(amount);
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template =
                 $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Query<{generics}>(in QueryDescription description, ForEach<{generics}> forEach)
+public void Query<{generics}>(in QueryDescription description, ForEach<{generics}> forEach) {whereT}
 {{
     var query = Query(in description);
     foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -100,11 +105,12 @@ public void Query<{generics}>(in QueryDescription description, ForEach<{generics
         var getFirstElement = new StringBuilder().GetFirstGenericElements(amount);
         var getComponents = new StringBuilder().GetGenericComponents(amount);
         var insertParams = new StringBuilder().InsertGenericParams(amount);
+        var whereT = new StringBuilder().GenericWhereStruct(amount);
 
         var template =
                 $@"
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public void Query<{generics}>(in QueryDescription description, ForEachWithEntity<{generics}> forEach)
+public void Query<{generics}>(in QueryDescription description, ForEachWithEntity<{generics}> forEach) {whereT}
 {{
     var query = Query(in description);
     foreach (ref var chunk in query.GetChunkIterator()) {{ 
@@ -112,7 +118,7 @@ public void Query<{generics}>(in QueryDescription description, ForEachWithEntity
         var chunkSize = chunk.Size;
         {getArrays}
 
-        ref var entityFirstElement = ref ArrayExtensions.DangerousGetReference(chunk.Entities);
+        ref var entityFirstElement = ref MemoryMarshal.GetReference<Entity>(chunk.Entities);
         {getFirstElement}
 
         for (var entityIndex = chunkSize - 1; entityIndex >= 0; --entityIndex) {{

--- a/Arch.SourceGenerator/QueryGenerator.cs
+++ b/Arch.SourceGenerator/QueryGenerator.cs
@@ -13,7 +13,7 @@ public class QueryGenerator : IIncrementalGenerator
     {
         if (!Debugger.IsAttached)
         {
-            //Debugger.Launch();
+            Debugger.Launch();
         }
 
         context.RegisterPostInitializationOutput(initializationContext =>
@@ -54,17 +54,36 @@ public class QueryGenerator : IIncrementalGenerator
             jobs.AppendIForEachJobs(25);
             jobs.AppendIForEachWithEntityJobs(25);
 
-            var queries = CodeBuilder.Create("Arch.Core")
-                .AddNamespaceImport("System")
-                .AddNamespaceImport("System.Runtime.CompilerServices")
-                .AddNamespaceImport("CommunityToolkit.HighPerformance;")
-                .AddNamespaceImport("JobScheduler")
-                .AddNamespaceImport("Arch.Core.Utils")
-                .AddClass("World").MakePublicClass();
-            queries.AppendQueryMethods(25);
-            queries.AppendEntityQueryMethods(25);
-            queries.AppendParallelQuerys(25);
-            queries.AppendParallelEntityQuerys(25);
+            //var queries = CodeBuilder.Create("Arch.Core")
+            //    .AddNamespaceImport("System")
+            //    .AddNamespaceImport("System.Runtime.CompilerServices")
+            //    .AddNamespaceImport("CommunityToolkit.HighPerformance;")
+            //    .AddNamespaceImport("JobScheduler")
+            //    .AddNamespaceImport("Arch.Core.Utils")
+            //    .AddClass("World").MakePublicClass();
+            //queries.AppendQueryMethods(25);
+            //queries.AppendEntityQueryMethods(25);
+            //queries.AppendParallelQuerys(25);
+            //queries.AppendParallelEntityQuerys(25);
+
+            var queries = new StringBuilder();
+            queries.AppendLine("using System;");
+            queries.AppendLine("using System.Runtime.CompilerServices;");
+            queries.AppendLine("using JobScheduler;");
+            queries.AppendLine("using Arch.Core.Utils;");
+            queries.AppendLine("using CommunityToolkit.HighPerformance;");
+            queries.AppendLine("using ArrayExtensions = CommunityToolkit.HighPerformance.ArrayExtensions;");
+            queries.AppendLine("namespace Arch.Core;");
+            queries.AppendLine($@"
+                
+                public partial class World
+                {{
+                    {new StringBuilder().AppendQueryMethods(25)}
+                    {new StringBuilder().AppendEntityQueryMethods(25)}
+                }}
+
+            ");
+
 
             var acessors = new StringBuilder();
             acessors.AppendLine("using System;");
@@ -137,7 +156,7 @@ public class QueryGenerator : IIncrementalGenerator
                 CSharpSyntaxTree.ParseText(jobs.ToString()).GetRoot().NormalizeWhitespace().ToFullString());
 
             initializationContext.AddSource("World.g.cs",
-                CSharpSyntaxTree.ParseText(queries.Build()).GetRoot().NormalizeWhitespace().ToFullString());
+                CSharpSyntaxTree.ParseText(queries.ToString()).GetRoot().NormalizeWhitespace().ToFullString());
 
             initializationContext.AddSource("Acessors.g.cs",
                 CSharpSyntaxTree.ParseText(acessors.ToString()).GetRoot().NormalizeWhitespace().ToFullString());

--- a/Arch.SourceGenerator/QueryGenerator.cs
+++ b/Arch.SourceGenerator/QueryGenerator.cs
@@ -18,53 +18,43 @@ public class QueryGenerator : IIncrementalGenerator
 
         context.RegisterPostInitializationOutput(initializationContext =>
         {
+            const int METHOD_COUNT = 25;
 
             var compileTimeStatics = new StringBuilder();
             compileTimeStatics.AppendLine("using System;");
             compileTimeStatics.AppendLine("namespace Arch.Core.Utils;");
-            compileTimeStatics.AppendGroups(25);
+            compileTimeStatics.AppendGroups(METHOD_COUNT);
             
             var delegates = new StringBuilder();
             delegates.AppendLine("using System;");
             delegates.AppendLine("namespace Arch.Core;");
-            delegates.AppendForEachDelegates(25);
-            delegates.AppendForEachEntityDelegates(25);
+            delegates.AppendForEachDelegates(METHOD_COUNT);
+            delegates.AppendForEachEntityDelegates(METHOD_COUNT);
 
             var interfaces = new StringBuilder();
             interfaces.AppendLine("using System;");
             interfaces.AppendLine("using System.Runtime.CompilerServices;");
             interfaces.AppendLine("namespace Arch.Core;");
-            interfaces.AppendInterfaces(25);
-            interfaces.AppendEntityInterfaces(25);
+            interfaces.AppendInterfaces(METHOD_COUNT);
+            interfaces.AppendEntityInterfaces(METHOD_COUNT);
             
             var references = new StringBuilder();
             references.AppendLine("using System;");
             references.AppendLine("using System.Runtime.CompilerServices;");
             references.AppendLine("using CommunityToolkit.HighPerformance;");
             references.AppendLine("namespace Arch.Core;");
-            references.AppendReferences(25);
+            references.AppendReferences(METHOD_COUNT);
 
             var jobs = new StringBuilder();
             jobs.AppendLine("using System;");
             jobs.AppendLine("using System.Runtime.CompilerServices;");
             jobs.AppendLine("using ArrayExtensions = CommunityToolkit.HighPerformance.ArrayExtensions;");
             jobs.AppendLine("namespace Arch.Core;");
-            jobs.AppendForEachJobs(25);
-            jobs.AppendEntityForEachJobs(25);
-            jobs.AppendIForEachJobs(25);
-            jobs.AppendIForEachWithEntityJobs(25);
+            jobs.AppendForEachJobs(METHOD_COUNT);
+            jobs.AppendEntityForEachJobs(METHOD_COUNT);
+            jobs.AppendIForEachJobs(METHOD_COUNT);
+            jobs.AppendIForEachWithEntityJobs(METHOD_COUNT);
 
-            //var queries = CodeBuilder.Create("Arch.Core")
-            //    .AddNamespaceImport("System")
-            //    .AddNamespaceImport("System.Runtime.CompilerServices")
-            //    .AddNamespaceImport("CommunityToolkit.HighPerformance;")
-            //    .AddNamespaceImport("JobScheduler")
-            //    .AddNamespaceImport("Arch.Core.Utils")
-            //    .AddClass("World").MakePublicClass();
-            //queries.AppendQueryMethods(25);
-            //queries.AppendEntityQueryMethods(25);
-            //queries.AppendParallelQuerys(25);
-            //queries.AppendParallelEntityQuerys(25);
 
             var queries = new StringBuilder();
             queries.AppendLine("using System;");
@@ -78,8 +68,10 @@ public class QueryGenerator : IIncrementalGenerator
                 
                 public partial class World
                 {{
-                    {new StringBuilder().AppendQueryMethods(25)}
-                    {new StringBuilder().AppendEntityQueryMethods(25)}
+                    {new StringBuilder().AppendQueryMethods(METHOD_COUNT)}
+                    {new StringBuilder().AppendEntityQueryMethods(METHOD_COUNT)}
+                    {new StringBuilder().AppendParallelQuerys(METHOD_COUNT)}
+                    {new StringBuilder().AppendParallelEntityQuerys(METHOD_COUNT)}
                 }}
 
             ");
@@ -97,33 +89,33 @@ public class QueryGenerator : IIncrementalGenerator
             acessors.AppendLine($@"
                
                 public partial struct Chunk{{
-                    {new StringBuilder().AppendChunkHases(25)}
-                    {new StringBuilder().AppendChunkIndexGets(25)}        
-                    {new StringBuilder().AppendChunkIndexSets(25)}
+                    {new StringBuilder().AppendChunkHases(METHOD_COUNT)}
+                    {new StringBuilder().AppendChunkIndexGets(METHOD_COUNT)}        
+                    {new StringBuilder().AppendChunkIndexSets(METHOD_COUNT)}
                 }}
 
                 public partial class Archetype{{
-                    {new StringBuilder().AppendArchetypeHases(25)}
-                    {new StringBuilder().AppendArchetypeGets(25)}
-                    {new StringBuilder().AppendArchetypeSets(25)}
+                    {new StringBuilder().AppendArchetypeHases(METHOD_COUNT)}
+                    {new StringBuilder().AppendArchetypeGets(METHOD_COUNT)}
+                    {new StringBuilder().AppendArchetypeSets(METHOD_COUNT)}
                 }}
             
                 public partial class World{{
-                    {new StringBuilder().AppendCreates(25)}
-                    {new StringBuilder().AppendWorldHases(25)}
-                    {new StringBuilder().AppendWorldGets(25)}
-                    {new StringBuilder().AppendWorldSets(25)}
-                    {new StringBuilder().AppendWorldAdds(25)}    
-                    {new StringBuilder().AppendWorldRemoves(25)}
+                    {new StringBuilder().AppendCreates(METHOD_COUNT)}
+                    {new StringBuilder().AppendWorldHases(METHOD_COUNT)}
+                    {new StringBuilder().AppendWorldGets(METHOD_COUNT)}
+                    {new StringBuilder().AppendWorldSets(METHOD_COUNT)}
+                    {new StringBuilder().AppendWorldAdds(METHOD_COUNT)}    
+                    {new StringBuilder().AppendWorldRemoves(METHOD_COUNT)}
                 }}
 
                public static partial class EntityExtensions{{
                 #if !PURE_ECS
-                    {new StringBuilder().AppendEntityHases(25)}
-                    {new StringBuilder().AppendEntitySets(25)}
-                    {new StringBuilder().AppendEntityGets(25)}
-                    {new StringBuilder().AppendEntityAdds(25)}
-                    {new StringBuilder().AppendEntityRemoves(25)}
+                    {new StringBuilder().AppendEntityHases(METHOD_COUNT)}
+                    {new StringBuilder().AppendEntitySets(METHOD_COUNT)}
+                    {new StringBuilder().AppendEntityGets(METHOD_COUNT)}
+                    {new StringBuilder().AppendEntityAdds(METHOD_COUNT)}
+                    {new StringBuilder().AppendEntityRemoves(METHOD_COUNT)}
                 #endif
                 }}
             ");
@@ -135,10 +127,10 @@ public class QueryGenerator : IIncrementalGenerator
             hpQueries.AppendLine("using ArrayExtensions = CommunityToolkit.HighPerformance.ArrayExtensions;");
             hpQueries.AppendLine("using Arch.Core.Utils;");
             hpQueries.AppendLine("namespace Arch.Core;");
-            hpQueries.AppendQueryInterfaceMethods(25);
-            hpQueries.AppendEntityQueryInterfaceMethods(25);
-            hpQueries.AppendHpParallelQuerys(25);
-            hpQueries.AppendHpeParallelQuerys(25);
+            hpQueries.AppendQueryInterfaceMethods(METHOD_COUNT);
+            hpQueries.AppendEntityQueryInterfaceMethods(METHOD_COUNT);
+            hpQueries.AppendHpParallelQuerys(METHOD_COUNT);
+            hpQueries.AppendHpeParallelQuerys(METHOD_COUNT);
 
             initializationContext.AddSource("CompileTimeStatics.g.cs",
                 CSharpSyntaxTree.ParseText(compileTimeStatics.ToString()).GetRoot().NormalizeWhitespace().ToFullString());

--- a/Arch.SourceGenerator/QueryGenerator.cs
+++ b/Arch.SourceGenerator/QueryGenerator.cs
@@ -47,6 +47,7 @@ public class QueryGenerator : IIncrementalGenerator
             var jobs = new StringBuilder();
             jobs.AppendLine("using System;");
             jobs.AppendLine("using System.Runtime.CompilerServices;");
+            jobs.AppendLine("using System.Runtime.InteropServices;");
             jobs.AppendLine("using ArrayExtensions = CommunityToolkit.HighPerformance.ArrayExtensions;");
             jobs.AppendLine("namespace Arch.Core;");
             jobs.AppendForEachJobs(25);

--- a/Arch.SourceGenerator/QueryGenerator.cs
+++ b/Arch.SourceGenerator/QueryGenerator.cs
@@ -57,6 +57,7 @@ public class QueryGenerator : IIncrementalGenerator
             var acessors = new StringBuilder();
             acessors.AppendLine("using System;");
             acessors.AppendLine("using System.Runtime.CompilerServices;");
+            acessors.AppendLine("using System.Runtime.InteropServices;");
             acessors.AppendLine("using JobScheduler;");
             acessors.AppendLine("using Arch.Core.Utils;");
             acessors.AppendLine("using System.Diagnostics.Contracts;");

--- a/Arch.SourceGenerator/StringBuilderExtensions.cs
+++ b/Arch.SourceGenerator/StringBuilderExtensions.cs
@@ -10,6 +10,13 @@ public static class StringBuilderExtensions
         return sb;
     }
 
+    public static StringBuilder GenericWhereStruct(this StringBuilder sb, int amount)
+    {
+        for (var localIndex = 0; localIndex <= amount; localIndex++) 
+            sb.Append($" where T{localIndex}: struct ");
+        return sb;
+    }
+
     public static StringBuilder Generic(this StringBuilder sb, int amount)
     {
         sb.Append("<");
@@ -39,7 +46,7 @@ public static class StringBuilderExtensions
     public static StringBuilder GetFirstGenericElements(this StringBuilder sb, int amount)
     {
         for (var localIndex = 0; localIndex <= amount; localIndex++)
-            sb.AppendLine($"ref var t{localIndex}FirstElement = ref ArrayExtensions.DangerousGetReference(t{localIndex}Array);");
+            sb.AppendLine($"ref var t{localIndex}FirstElement = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(t{localIndex}Array);");
 
         return sb;
     }
@@ -47,7 +54,7 @@ public static class StringBuilderExtensions
     public static StringBuilder GetLastGenericElements(this StringBuilder sb, int amount)
     {
         for (var localIndex = 0; localIndex <= amount; localIndex++)
-            sb.AppendLine($"ref var t{localIndex}LastElement = ref ArrayExtensions.DangerousGetReferenceAt(t{localIndex}Array, chunkSize-1);");
+            sb.AppendLine($"ref var t{localIndex}LastElement = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(t{localIndex}Array.Slice(chunkSize-1));");
 
         return sb;
     }

--- a/Arch.Test/ArchetypeTest.cs
+++ b/Arch.Test/ArchetypeTest.cs
@@ -131,18 +131,22 @@ public class ArchetypeTest
         archetype.Add(entity, out var entityOneSlot);
         otherArchetype.Add(otherEntity, out var entityTwoSlot);
         
-        archetype.Set(ref entityOneSlot, new Transform{ X = 10, Y = 10});
-        archetype.Set(ref entityOneSlot, new Rotation{ X = 10, Y = 10});
+        archetype.Set(ref entityOneSlot, new Transform{ X = 1, Y = 2});
+        archetype.Set(ref entityOneSlot, new Rotation{ X = 3, Y = 4});
 
         otherArchetype.Add(entity, out var newSlot);
         archetype.CopyTo(otherArchetype, ref entityOneSlot, ref newSlot);
         archetype.Remove(ref entityOneSlot, out var replacedEntityId);
-    
+
+        ref var xx = ref otherArchetype.Get<Transform>(ref newSlot);
+        ref var yy = ref otherArchetype.Get<Rotation>(ref newSlot);
+
+
         Assert.AreEqual(0, archetype.Chunks[0].Size);
         Assert.AreEqual(2, otherArchetype.Chunks[0].Size);
-        Assert.AreEqual(10, otherArchetype.Get<Transform>(ref newSlot).X);
-        Assert.AreEqual(10, otherArchetype.Get<Transform>(ref newSlot).Y);
-        Assert.AreEqual(10, otherArchetype.Get<Rotation>(ref newSlot).X);
-        Assert.AreEqual(10, otherArchetype.Get<Rotation>(ref newSlot).Y);
+        Assert.AreEqual(1, otherArchetype.Get<Transform>(ref newSlot).X);
+        Assert.AreEqual(2, otherArchetype.Get<Transform>(ref newSlot).Y);
+        Assert.AreEqual(3, otherArchetype.Get<Rotation>(ref newSlot).X);
+        Assert.AreEqual(4, otherArchetype.Get<Rotation>(ref newSlot).Y);
     }
 }

--- a/Arch/Core/Archetype.cs
+++ b/Arch/Core/Archetype.cs
@@ -172,7 +172,7 @@ public sealed unsafe partial class Archetype
     /// <param name="cmp">The component</param>
     /// <typeparam name="T">The type</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void Set<T>(ref Slot slot, in T cmp)
+    internal void Set<T>(ref Slot slot, in T cmp) where T : struct
     {
         ref var chunk = ref GetChunk(slot.ChunkIndex);
         chunk.Set(slot.Index, in cmp);
@@ -184,7 +184,7 @@ public sealed unsafe partial class Archetype
     /// <typeparam name="T">The type</typeparam>
     /// <returns>True if it does, false if it doesnt</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Has<T>()
+    public bool Has<T>() where T : struct
     { 
         var id = Component<T>.ComponentType.Id;
         return BitSet.IsSet(id);
@@ -197,7 +197,7 @@ public sealed unsafe partial class Archetype
     /// <typeparam name="T">The type</typeparam>
     /// <returns>The component</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal unsafe ref T Get<T>(scoped ref Slot slot)
+    internal unsafe ref T Get<T>(scoped ref Slot slot) where T : struct
     {
         ref var chunk = ref GetChunk(slot.ChunkIndex);
         return ref chunk.Get<T>(in slot.Index);

--- a/Arch/Core/Chunk.cs
+++ b/Arch/Core/Chunk.cs
@@ -11,7 +11,7 @@ namespace Arch.Core;
 
 public sealed class ComponentArray
 {
-    private byte[] _array;
+    private readonly byte[] _array;
 
     public ComponentArray(ComponentType type, int size)
     {
@@ -136,14 +136,16 @@ public partial struct Chunk
     {
         // Last entity in archetype. 
         var lastIndex = Size - 1;
-      
+        
         // Copy last entity to replace the removed one
         Entities[index] = Entities[lastIndex];
         for (var i = 0; i < Components.Length; i++)
         {
             var size = Components[i].ElementType.ByteSize;
-            var array = Components[i].GetSpan<byte>();
-            array.Slice(lastIndex * size, 1 * size).CopyTo(array.Slice(index * size, 1 * size));
+            var span = Components[i].GetSpan<byte>();
+
+            span.Slice(lastIndex * size, size)
+                .CopyTo(span.Slice(index * size, size));
         }
 
         // Update the mapping
@@ -341,12 +343,14 @@ public partial struct Chunk
         // Move/Copy components to the new chunk
         for (var i = 0; i < Components.Length; i++)
         {
+            // they are suppose to be similar, so the byte size is the same
             var size = Components[i].ElementType.ByteSize;
 
             var sourceArray = Components[i].GetSpan<byte>();
             var desArray = toChunk.Components[i].GetSpan<byte>();
 
-            sourceArray.Slice(toIndex * size, 1 * size).CopyTo(desArray.Slice(index * size, 1 * size));
+            sourceArray.Slice(toIndex * size, size)
+                .CopyTo(desArray.Slice(index * size, size));
         }
     }
     
@@ -369,8 +373,9 @@ public partial struct Chunk
             var sourceArray = Components[i].GetSpan<byte>();
             var desArray = toChunk.GetArray(sourceType);
 
-            sourceArray.Slice(index * sourceType.ByteSize, 1 * sourceType.ByteSize)
-                .CopyTo(desArray.Slice(toIndex * sourceType.ByteSize, 1 * sourceType.ByteSize));
+            // they are suppose to be similar, so the byte size is the same
+            sourceArray.Slice(index * sourceType.ByteSize, sourceType.ByteSize)
+                .CopyTo(desArray.Slice(toIndex * sourceType.ByteSize, sourceType.ByteSize));
         }
     }
 
@@ -390,13 +395,14 @@ public partial struct Chunk
         Entities[index] = lastEntity;
         for (var i = 0; i < Components.Length; i++)
         {
+            // they are suppose to be similar, so the byte size is the same
             var size = Components[i].ElementType.ByteSize;
 
             var sourceArray = chunk.Components[i].GetSpan<byte>();
             var desArray = Components[i].GetSpan<byte>();
 
-            sourceArray.Slice(lastIndex * size, 1 * size)
-                .CopyTo(desArray.Slice(index * size, 1 * size));
+            sourceArray.Slice(lastIndex * size, size)
+                .CopyTo(desArray.Slice(index * size, size));
         }
         
         chunk.Size--;

--- a/Arch/Core/Chunk.cs
+++ b/Arch/Core/Chunk.cs
@@ -9,6 +9,9 @@ using CommunityToolkit.HighPerformance;
 
 namespace Arch.Core;
 
+/// <summary>
+/// Rappresents a raw buffer of a specific component type
+/// </summary>
 public sealed class ComponentArray
 {
     private readonly byte[] _array;

--- a/Arch/Core/Chunk.cs
+++ b/Arch/Core/Chunk.cs
@@ -13,15 +13,14 @@ public sealed class ComponentArray
 {
     private byte[] _array;
 
-    //public byte[] Array => _array;
-
-    public ComponentType ElementType { get; }
-
     public ComponentArray(ComponentType type, int size)
     {
         _array = new byte[size];
         ElementType = type;
     }
+
+
+    public ComponentType ElementType { get; }
 
     public Span<T> GetSpan<T>() where T : struct => MemoryMarshal.Cast<byte, T>(_array);
 

--- a/Arch/Core/Chunk.cs
+++ b/Arch/Core/Chunk.cs
@@ -16,10 +16,12 @@ public sealed class ComponentArray<T> where T : IComponent
     private T[] _array;
 
     public T[] Array => _array;
+    public Type ElementType { get; }
 
-    public ComponentArray(int size)
+    public ComponentArray(Type type, int size)
     {
         _array = new T[size];
+        ElementType = type;
     }
 
     public ref T GetComponenet(int index) => ref _array[index];
@@ -67,7 +69,7 @@ public partial struct Chunk
         ComponentIdToArrayIndex = componentIdToArrayIndex;
         for (var index = 0; index < types.Length; index++)
         {
-            Components[index] = new ComponentArray<IComponent>(Capacity);
+            Components[index] = new ComponentArray<IComponent>(types[index], Capacity);
         }
     }
 
@@ -355,7 +357,7 @@ public partial struct Chunk
         for (var i = 0; i < Components.Length; i++)
         {
             var sourceArray = Components[i].Array;
-            var sourceType = sourceArray.GetType().GetElementType();
+            var sourceType = Components[i].ElementType;
 
             if (!toChunk.Has(sourceType)) continue;
             

--- a/Arch/Core/CommandBuffer/CommandBuffer.cs
+++ b/Arch/Core/CommandBuffer/CommandBuffer.cs
@@ -154,7 +154,7 @@ public class CommandBuffer : IDisposable
     /// <param name="component">The component instance</param>
     /// <typeparam name="T">The generic type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Set<T>(in Entity entity, in T component)
+    public void Set<T>(in Entity entity, in T component) where T : struct
     {
         BufferedEntityInfo info;
         lock (this)
@@ -173,7 +173,7 @@ public class CommandBuffer : IDisposable
     /// <param name="component">The component instance.</param>
     /// <typeparam name="T">The generic type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in Entity entity, in T component)
+    public void Add<T>(in Entity entity, in T component) where T : struct
     {
         BufferedEntityInfo info;
         lock (this)
@@ -192,7 +192,7 @@ public class CommandBuffer : IDisposable
     /// <param name="entity">The entity which we wanna remove a component from.</param>
     /// <typeparam name="T">The generic type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Remove<T>(in Entity entity)
+    public void Remove<T>(in Entity entity) where T : struct
     {
         BufferedEntityInfo info;
         lock (this)
@@ -283,7 +283,10 @@ public class CommandBuffer : IDisposable
                 if(!sparseArray.Has(id)) continue;
 
                 var chunkArray = chunk.GetArray(sparseArray.Type);
-                Array.Copy(sparseArray.Components.Array, id, chunkArray, chunkIndex, 1);
+                var src = sparseArray.Components.GetSpan<byte>();
+                var size = sparseArray.Components.ElementType.ByteSize;
+
+                src.Slice(id * size, 1 * size).CopyTo(chunkArray.Slice(chunkIndex * size, 1 * size));
             }
         }
         

--- a/Arch/Core/CommandBuffer/CommandBuffer.cs
+++ b/Arch/Core/CommandBuffer/CommandBuffer.cs
@@ -283,7 +283,7 @@ public class CommandBuffer : IDisposable
                 if(!sparseArray.Has(id)) continue;
 
                 var chunkArray = chunk.GetArray(sparseArray.Type);
-                Array.Copy(sparseArray.Components, id, chunkArray, chunkIndex, 1);
+                Array.Copy(sparseArray.Components.Array, id, chunkArray, chunkIndex, 1);
             }
         }
         

--- a/Arch/Core/CommandBuffer/CommandBuffer.cs
+++ b/Arch/Core/CommandBuffer/CommandBuffer.cs
@@ -286,7 +286,8 @@ public class CommandBuffer : IDisposable
                 var src = sparseArray.Components.GetSpan<byte>();
                 var size = sparseArray.Components.ElementType.ByteSize;
 
-                src.Slice(id * size, 1 * size).CopyTo(chunkArray.Slice(chunkIndex * size, 1 * size));
+                src.Slice(id * size, size)
+                    .CopyTo(chunkArray.Slice(chunkIndex * size, size));
             }
         }
         

--- a/Arch/Core/CommandBuffer/SparseSet.cs
+++ b/Arch/Core/CommandBuffer/SparseSet.cs
@@ -37,7 +37,7 @@ internal class SparseArray : IDisposable
     /// <summary>
     /// The component array of <see cref="Type"/>. 
     /// </summary>
-    public Array Components { get; private set; }
+    public ComponentArray<IComponent> Components { get; private set; }
 
     public SparseArray(ComponentType type, int capacity = 64)
     {
@@ -47,7 +47,7 @@ internal class SparseArray : IDisposable
         Size = 0;
         Entities = new int[Capacity];
         Array.Fill(Entities, -1);
-        Components = Array.CreateInstance(type, Capacity);
+        Components = new ComponentArray<IComponent>(type, Capacity);
     }
 
     /// <summary>
@@ -71,11 +71,11 @@ internal class SparseArray : IDisposable
             Size++;
 
             // Resize components
-            if (Size < Components.Length) return;
+            if (Size < Components.Array.Length) return;
 
             Capacity = Capacity <= 0 ? 1 : Capacity;
-            var array = Array.CreateInstance(Type, Capacity * 2);
-            Components.CopyTo(array, 0);
+            var array = new ComponentArray<IComponent>(Type, Capacity * 2);
+            Components.Array.CopyTo(array.Array, 0);
             Components = array;
             Capacity *= 2;
         }
@@ -100,7 +100,7 @@ internal class SparseArray : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private T[] GetArray<T>()
     {
-        return Unsafe.As<T[]>(Components);
+        return Unsafe.As<T[]>(Components.Array);
     }
 
     /// <summary>

--- a/Arch/Core/Extensions/EntityExtensions.cs
+++ b/Arch/Core/Extensions/EntityExtensions.cs
@@ -89,7 +89,7 @@ public static partial class EntityExtensions
     /// <param name="component">A reference to the component</param>
     /// <typeparam name="T">The component type</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Set<T>(this in Entity entity, in T component)
+    public static void Set<T>(this in Entity entity, in T component) where T : struct
     { 
         var world = World.Worlds[entity.WorldId];
         world.Set(in entity, in component);
@@ -102,7 +102,7 @@ public static partial class EntityExtensions
     /// <typeparam name="T">The component type</typeparam>
     /// <returns>True if it exists for that entity</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool Has<T>(this in Entity entity)
+    public static bool Has<T>(this in Entity entity) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         return world.Has<T>(in entity);
@@ -115,7 +115,7 @@ public static partial class EntityExtensions
     /// <typeparam name="T">The component type</typeparam>
     /// <returns>A reference to the component</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T Get<T>(this in Entity entity)
+    public static ref T Get<T>(this in Entity entity) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         return ref world.Get<T>(entity);
@@ -130,7 +130,7 @@ public static partial class EntityExtensions
     /// <param name="component">The component itself</param>
     /// <returns>True if the component exists on the entity and could be returned.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryGet<T>(this in Entity entity, out T component)
+    public static bool TryGet<T>(this in Entity entity, out T component) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         return world.TryGet(in entity, out component);
@@ -145,7 +145,7 @@ public static partial class EntityExtensions
     /// <param name="component">The component itself</param>
     /// <returns>True if the component exists on the entity and could be returned.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T TryGetRef<T>(this in Entity entity, out bool exists)
+    public static ref T TryGetRef<T>(this in Entity entity, out bool exists) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         return ref world.TryGetRef<T>(in entity, out exists);
@@ -159,7 +159,7 @@ public static partial class EntityExtensions
     /// <param name="component">The component itself</param>
     /// <returns>True if the component exists on the entity and could be returned.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Add<T>(this in Entity entity, in T cmp = default)
+    public static void Add<T>(this in Entity entity, in T cmp = default) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         world.Add<T>(in entity);
@@ -173,7 +173,7 @@ public static partial class EntityExtensions
     /// <param name="component">The component itself</param>
     /// <returns>True if the component exists on the entity and could be returned.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Remove<T>(this in Entity entity)
+    public static void Remove<T>(this in Entity entity) where T : struct
     {
         var world = World.Worlds[entity.WorldId];
         world.Remove<T>(in entity);

--- a/Arch/Core/Query.cs
+++ b/Arch/Core/Query.cs
@@ -33,7 +33,7 @@ public partial struct QueryDescription : IEquatable<QueryDescription>
     /// <typeparam name="T">The generic.</typeparam>
     /// <returns>Reference to this instance for chaining calls.</returns>
     [UnscopedRef]
-    public ref QueryDescription WithAll<T>()
+    public ref QueryDescription WithAll<T>() where T: struct
     {
         All = Group<T>.Types;
         return ref this;
@@ -46,7 +46,7 @@ public partial struct QueryDescription : IEquatable<QueryDescription>
     /// <typeparam name="T">The generic.</typeparam>
     /// <returns>Reference to this instance for chaining calls.</returns>
     [UnscopedRef]
-    public ref QueryDescription WithAny<T>()
+    public ref QueryDescription WithAny<T>() where T : struct
     {
         Any = Group<T>.Types;
         return ref this;
@@ -59,7 +59,7 @@ public partial struct QueryDescription : IEquatable<QueryDescription>
     /// <typeparam name="T">The generic.</typeparam>
     /// <returns>Reference to this instance for chaining calls.</returns>
     [UnscopedRef]
-    public ref QueryDescription WithNone<T>()
+    public ref QueryDescription WithNone<T>() where T : struct
     {
         None = Group<T>.Types;
         return ref this;
@@ -72,7 +72,7 @@ public partial struct QueryDescription : IEquatable<QueryDescription>
     /// <typeparam name="T">The generic.</typeparam>
     /// <returns>Reference to this instance for chaining calls.</returns>
     [UnscopedRef]
-    public ref QueryDescription WithExclusive<T>()
+    public ref QueryDescription WithExclusive<T>() where T : struct
     {
         Exclusive = Group<T>.Types;
         return ref this;

--- a/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/Arch/Core/Utils/CompileTimeStatics.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.ObjectPool;
@@ -88,7 +87,7 @@ public static class ComponentRegistry
         
         // Register and assign component id
         var size = Marshal.SizeOf(type);
-        meta = new ComponentType(Size, type, size, type.GetFields().Length == 0);
+        meta = new ComponentType(Size, type, size, size - 1 <= 0);
         _types.Add(type, meta);
 
         Size++;
@@ -147,11 +146,7 @@ public static class ComponentRegistry
 /// <typeparam name="T"></typeparam>
 public static class Component<T>
 {
-    public static readonly ComponentType ComponentType;
-    static Component()
-    {
-        ComponentType = ComponentRegistry.Add<T>();
-    }
+    public static readonly ComponentType ComponentType = ComponentRegistry.Add<T>();
 }
 
 /// <summary>

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Arch.Core.Extensions;
@@ -868,10 +865,15 @@ public partial class World
         {
             var componentArray = components[index];
             var size = componentArray.ElementType.ByteSize;
+            var span = componentArray.GetSpan<byte>();
 
-            // FIXME
-            //ref var component = ref componentArray.GetComponent<object>(entityIndex);
-            //cmps[index] = component;
+            unsafe
+            {
+                fixed (byte* ptr = &MemoryMarshal.GetReference(span.Slice(entityIndex * size, size)))
+                {
+                    cmps[index] = Marshal.PtrToStructure((nint) ptr, componentArray.ElementType.Type);
+                }
+            }
         }
 
         return cmps;

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -867,7 +867,7 @@ public partial class World
         for (var index = 0; index < components.Length; index++)
         {
             var componentArray = components[index];
-            var component = componentArray.GetValue(entityIndex);
+            ref var component = ref componentArray.GetComponenet(entityIndex);
             cmps[index] = component;
         }
 

--- a/Arch/Core/World.cs
+++ b/Arch/Core/World.cs
@@ -709,7 +709,7 @@ public partial class World
     /// <param name="cmp">The component instance.</param>
     /// <typeparam name="T">The generic/component type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Set<T>(in Entity entity, in T cmp = default)
+    public void Set<T>(in Entity entity, in T cmp = default) where T : struct
     {
         var entityInfo = EntityInfo[entity.Id];
         entityInfo.Archetype.Set(ref entityInfo.Slot, in cmp);
@@ -722,7 +722,7 @@ public partial class World
     /// <typeparam name="T">The component type</typeparam>
     /// <returns>True if it exists for that entity</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Has<T>(in Entity entity)
+    public bool Has<T>(in Entity entity) where T : struct
     {
         var archetype = EntityInfo[entity.Id].Archetype;
         return archetype.Has<T>();
@@ -735,7 +735,7 @@ public partial class World
     /// <typeparam name="T">The generic/component type.</typeparam>
     /// <returns>A reference to the entity component</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref T Get<T>(in Entity entity)
+    public ref T Get<T>(in Entity entity) where T: struct
     {
         var entityInfo = EntityInfo[entity.Id];
         return ref entityInfo.Archetype.Get<T>(ref entityInfo.Slot);
@@ -750,7 +750,7 @@ public partial class World
     /// <param name="component">The component itself</param>
     /// <returns>True if the component exists on the entity and could be returned.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryGet<T>(in Entity entity, out T component)
+    public bool TryGet<T>(in Entity entity, out T component) where T : struct
     {
         component = default;
         if (!Has<T>(in entity)) return false;
@@ -768,7 +768,7 @@ public partial class World
     /// <param name="exists">True if the component exists</param>
     /// <returns>The reference to the component or a nullref</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref T TryGetRef<T>(in Entity entity, out bool exists)
+    public ref T TryGetRef<T>(in Entity entity, out bool exists) where T : struct
     {
         if (!(exists = Has<T>(in entity)))
         {
@@ -867,8 +867,11 @@ public partial class World
         for (var index = 0; index < components.Length; index++)
         {
             var componentArray = components[index];
-            ref var component = ref componentArray.GetComponenet(entityIndex);
-            cmps[index] = component;
+            var size = componentArray.ElementType.ByteSize;
+
+            // FIXME
+            //ref var component = ref componentArray.GetComponent<object>(entityIndex);
+            //cmps[index] = component;
         }
 
         return cmps;
@@ -887,7 +890,7 @@ public partial class World{
     /// <param name="cmp">The component value.</param>
     /// <typeparam name="T">The Component.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in Entity entity)
+    public void Add<T>(in Entity entity) where T : struct
     {
         var oldArchetype = EntityInfo[entity.Id].Archetype;
 
@@ -936,7 +939,7 @@ public partial class World{
     /// <param name="cmp">The component value.</param>
     /// <typeparam name="T">The Component.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in Entity entity, in T cmp)
+    public void Add<T>(in Entity entity, in T cmp) where T : struct
     {  
         var oldArchetype = EntityInfo[entity.Id].Archetype;
 
@@ -959,7 +962,7 @@ public partial class World{
     /// <param name="cmp">The component value.</param>
     /// <typeparam name="T">The Component.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Remove<T>(in Entity entity)
+    public void Remove<T>(in Entity entity) where T : struct
     { 
         var oldArchetype = EntityInfo[entity.Id].Archetype;
 


### PR DESCRIPTION
## Main
To follow the project phylosophy, this PR aims to make Arch faster. 
As discussed in #40 Arch still using Reflection and an unconventional components access with the `Unsafe.As<T>` API. 

## The solution: use a bytes buffer
The `Archetype` class accepts a set of `Components` which the corrispective types are unknown at compile time and the opaque `Array` class get casted to a specific type using the `Unsafe.As<T>` API with some magic.
I replaced the `Array` with the following implementation
https://github.com/andreakarasho/Arch/blob/remove-reflection/Arch/Core/Chunk.cs#L12-L28
The hack is to use a `byte[sizeof(T) * Capacity]` array to store the components set.
In this way we can cast our components using the `MemoryMarshal.Cast<byte, TComponent>` API which garantees a `O(1)` operation.


## No managed references declared as struct field
Solution: usually ECS components contains an index to the managed resource
```csharp
// old
record struct Sprite(object Texture, Color color);

// new: use 'TextureID' to grab the resource
record struct Sprite(int TextureID, Color color);
```

About the `string` type I think to implement a struct which will handle the implicit convertion to unmanaged memory automatically. Something like in `flecs-cs`:
```csharp
record struct NameComponent(CString Value);
```
Reference: https://github.com/flecs-hub/flecs-cs/blob/main/src/cs/production/Flecs/flecs.cs#L11708-L11937

## No `class` components
I don't consider this a bad thing actually. I don't see a valid reason to use `class` components becase they cause addresses jump). So `struct` is the way to go!
Unity discourages the `class` usage too: https://docs.unity3d.com/Packages/com.unity.entities@0.16/manual/component_data.html#managed-icomponentdata

## The sample
### No reflection sample
https://user-images.githubusercontent.com/20810422/210229727-8cd4e1ec-fe47-4bc8-8d7e-3f5686723dfd.mp4

_(The initial fps drops was due to a misslick to the tiltle bar during the video recording)_

### Current `master` 
https://user-images.githubusercontent.com/20810422/210229801-bbe7d603-13bc-44a9-a85b-28f3eb1d2757.mp4


## TODO
- [x] code cleanup
- [x] documentation