### PR TITLE
Make SkipLocalsInit internal

### DIFF
--- a/src/Arch/Core/Utils/SkipLocalsInit.cs
+++ b/src/Arch/Core/Utils/SkipLocalsInit.cs
@@ -1,4 +1,4 @@
-namespace System.Runtime.CompilerServices;
+﻿namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(
     AttributeTargets.Module
@@ -9,7 +9,6 @@ namespace System.Runtime.CompilerServices;
     | AttributeTargets.Method
     | AttributeTargets.Property
     | AttributeTargets.Event, Inherited = false)]
-public sealed class SkipLocalsInitAttribute : Attribute
+internal sealed class SkipLocalsInitAttribute : Attribute
 {
-    public SkipLocalsInitAttribute() { }
 }


### PR DESCRIPTION
This causes errors for other projects on or above C# 9 that are using the original one, since SkipLocalsInit has a duplicate definition.
The other two fixes I could find are using reference aliases (see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0433), or propagating the attribute redefinition upwards.
I'm unsure if this breaks skipping local init, since Rider has a bug where it won't show that properly in its IL viewer (see https://youtrack.jetbrains.com/issue/RIDER-90904), this can be checked with ildasm.exe though.