### PR TITLE
Hide EntityDebugView behind !PURE_ECS

### DIFF
--- a/src/Arch/Core/Utils/EntityDebugView.cs
+++ b/src/Arch/Core/Utils/EntityDebugView.cs
@@ -1,3 +1,4 @@
+#if !PURE_ECS
 using Arch.Core.Extensions;
 
 namespace Arch.Core.Utils;
@@ -45,3 +46,5 @@ internal sealed class EntityDebugView
     /// </summary>
     public World World => IsAlive ? World.Worlds[_entity.WorldId] : null;
 }
+
+#endif


### PR DESCRIPTION
Without it, GetAllComponents (line 21), IsAlive (line 32) and WorldId (line 47) result in a compilation error since those are only available without PURE_ECS