### PR TITLE
Make World.Archetypes elements non-nullable and fix TryGetValue nullability

### DIFF
--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -114,7 +114,7 @@ public partial class World : IDisposable
     /// <summary>
     ///     All <see cref="Archetype"/>'s that exist in this <see cref="World"/>.
     /// </summary>
-    public PooledList<Archetype?> Archetypes { get; }
+    public PooledList<Archetype> Archetypes { get; }
 
     /// <summary>
     ///     Mapt an <see cref="Entity"/> to its <see cref="EntityInfo"/> for quick lookups.
@@ -164,7 +164,7 @@ public partial class World : IDisposable
         // Set archetypes to null to free them manually since Archetypes are set to ClearMode.Never to fix #65
         for (var index = 0; index < world.Archetypes.Count; index++)
         {
-            world.Archetypes[index] = null;
+            world.Archetypes[index] = null!;
         }
 
         world.Archetypes.Dispose();
@@ -311,8 +311,9 @@ public partial class World : IDisposable
         // Set archetypes to null to free them manually since Archetypes are set to ClearMode.Never to fix #65
         for (var index = 0; index < Archetypes.Count; index++)
         {
-            Archetypes[index] = null;
+            Archetypes[index] = null!;
         }
+
         Archetypes.Clear();
     }
 

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -474,7 +474,7 @@ public partial class World
     /// <param name="archetype">The found <see cref="Archetype"/>.</param>
     /// <returns>True if found, otherwhise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryGetArchetype(int hash, out Archetype archetype)
+    internal bool TryGetArchetype(int hash, [MaybeNullWhen(false)] out Archetype archetype)
     {
         return GroupToArchetype.TryGetValue(hash, out archetype);
     }
@@ -486,7 +486,7 @@ public partial class World
     /// <param name="archetype">The found <see cref="Archetype"/>.</param>
     /// <returns>True if found, otherwhise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryGetArchetype(ComponentType[] types, out Archetype archetype)
+    public bool TryGetArchetype(ComponentType[] types, [MaybeNullWhen(false)] out Archetype archetype)
     {
         var hash = Component.GetHashCode(types);
         return GroupToArchetype.TryGetValue(hash, out archetype);


### PR DESCRIPTION
Under regular use the elements are never null, they are only set to null when clearing or disposing the collection (on World.Clear and World.Destroy).
This PR instead ignores the nullability warning when setting the elements to null in those places, since they become inaccessible immediately after and are only used to make sure the memory gets freed.

This fixes a couple warnings:
![image](https://user-images.githubusercontent.com/10968691/232159400-233a04ad-21e2-4af0-b1ad-377f70f91884.png)

![image](https://user-images.githubusercontent.com/10968691/232159440-1b1f6e84-c17b-4fec-be8e-875dc17ada96.png)

![image](https://user-images.githubusercontent.com/10968691/232159453-27de24bb-866e-432e-9fb0-295be5e110d1.png)


Also fixes two nullability warnings in methods using TryGetValue