### PR TITLE
Remove leftover `in` from world.Reference(Entity) call

### DIFF
--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -276,7 +276,7 @@ public readonly struct EntityReference
     /// <returns>True if its alive, otherwhise false.</returns>
     public bool IsAlive(World world)
     {
-        var reference = world.Reference(in Entity);
+        var reference = world.Reference(Entity);
         return this == reference;
     }
 #else


### PR DESCRIPTION
It causes a compilation error with PURE_ECS enabled otherwise.
The method signature was changed in eb47ee37d1621a8649d331dc637216808222648a