### PR TITLE
Add version preprocessor to SkipLocalsInit and UnscopedRef

### DIFF
--- a/src/Arch/Core/Pollyfilling/SkipLocalsInit.cs
+++ b/src/Arch/Core/Pollyfilling/SkipLocalsInit.cs
@@ -1,4 +1,5 @@
-﻿namespace System.Runtime.CompilerServices;
+﻿#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
 
 /// <summary>
 ///     Forwards the SkipLocalInit to .NetStandard2.1.
@@ -15,3 +16,4 @@
 internal sealed class SkipLocalsInitAttribute : Attribute
 {
 }
+#endif

--- a/src/Arch/Core/Pollyfilling/UnscopedRef.cs
+++ b/src/Arch/Core/Pollyfilling/UnscopedRef.cs
@@ -1,6 +1,6 @@
+#if !NET7_0_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis;
 
-// NOTE: Should this be wrapped in `#if !NET7_0`?
 /// <summary>
 ///     Used to indicate a byref escapes and is not scoped.
 /// </summary>
@@ -24,3 +24,4 @@ public sealed class UnscopedRefAttribute : Attribute
     /// </summary>
     public UnscopedRefAttribute() { }
 }
+#endif


### PR DESCRIPTION
See the docs for [SkipLocalsInit](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute?view=net-8.0) and [UnscopedRef](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.unscopedrefattribute?view=net-8.0)
Also fixes some warnings about these attributes being duplicated.