### PR TITLE
IsAlive on dead reference should be false

### DIFF
--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -288,6 +288,10 @@ public readonly struct EntityReference
     /// <returns>True if its alive, otherwhise false.</returns>
     public bool IsAlive()
     {
+        if (this == Null)
+        {
+            return false;
+        }
         var reference = Entity.Reference();
         return this == reference;
     }

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1341,7 +1341,14 @@ public partial class World
     public EntityReference Reference(Entity entity)
     {
         var entityInfo = EntityInfo.TryGetVersion(entity.Id, out var version);
-        return new EntityReference(in entity, entityInfo ? version : 0);
+        if (entityInfo)
+        {
+            return new EntityReference(in entity, version);
+        }
+        else
+        {
+            return EntityReference.Null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
I found that `IsAlive()` on a reference to a deleted entity was returning `true`, leading to my code crashing.

I think the problem is that:
- `IsAlive()` does a version check by comparing `this` with `Entity.Reference()`. So if `Reference()` returns null or a different version, `IsAlive()` will be false (so far so good...)
- `Reference()` returns version `0` when an entity with a matching id is not found.
- So if you have a reference to version `0` of an entity, `IsAlive()` will always return `true` for it.

I fixed my problem by making `Reference()` return `EntityReference.Null` when an entity is not found.

This had the follow-on problem that `IsAlive()` would return `true` for `EntityReference.Null`, so I added a special case for that.