### PR TITLE
Add an implicit conversion operator for EntityReference > Entity

### DIFF
--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -365,6 +365,20 @@ public readonly struct EntityReference
     }
 
     /// <summary>
+    ///     Implicitly converts an <see cref="EntityReference"/> into the
+    ///     <see cref="Entity"/> that it is referencing.
+    /// </summary>
+    /// <param name="reference">The <see cref="EntityReference"/> to convert.</param>
+    /// <returns>
+    ///     The <see cref="Entity"/> referenced by this <see cref="EntityReference"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Entity(EntityReference reference)
+    {
+        return reference.Entity;
+    }
+
+    /// <summary>
     ///     Converts this <see cref="EntityReference"/> to a string.
     /// </summary>
     /// <returns>Its string.</returns>


### PR DESCRIPTION
Makes all calls to methods that take in an Entity easier if the value referenced is coming from a component, where `EntityReference` is supposed to be used instead of Entity.

For example:
```csharp
ref var map = ref World.TryGetRef<MapComponent>(mapId, out var exists);
```

Instead of:
```csharp
ref var map = ref World.TryGetRef<MapComponent>(mapId.Entity, out var exists);
```