### PR TITLE
Add Debug.Assert for chunk array index being out of bounds

### DIFF
--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -249,6 +249,7 @@ public partial struct Chunk
     public T[] GetArray<T>()
     {
         var index = Index<T>();
+        Debug.Assert(index != -1, "Index is out of bounds");
         ref var array = ref Components.DangerousGetReferenceAt(index);
         return Unsafe.As<T[]>(array);
     }


### PR DESCRIPTION
Prevents for example all running tests from crashing if one of them tries to get a type that doesn't exist in a chunk, if building on Debug.