### PR TITLE
Offset all component type ids by +1

### DIFF
--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -1,4 +1,3 @@
-using CommunityToolkit.HighPerformance;
 using Microsoft.Extensions.ObjectPool;
 
 namespace Arch.Core.Utils;
@@ -153,7 +152,7 @@ public static class ComponentRegistry
 
         // Register and assign component id
         var size = type.IsValueType ? Marshal.SizeOf(type) : IntPtr.Size;
-        meta = new ComponentType(Size, type, size, type.GetFields().Length == 0);
+        meta = new ComponentType(Size + 1, type, size, type.GetFields().Length == 0);
         _types.Add(type, meta);
 
         Size++;
@@ -239,8 +238,7 @@ public static class ComponentRegistry
         }
         else
         {
-            id = Size;
-            Size++;
+            id = ++Size;
         }
 
         var size = newType.IsValueType ? Marshal.SizeOf(newType) : IntPtr.Size;


### PR DESCRIPTION
This fixes a crash when adding a component with type id 0 to an entity, for example through world.Create(in comp).
If comp has a type id of 0 then an error is thrown when trying to index that type in the chunk, since the archetype retrieved for that type is the one associated with a component type hash of 0, which is the empty one.

I didn't make line 155 use Size++ so that the state doesn't get corrupted if _types.Add throws for some reason, since even though it checks at the start of the method I don't think it's made to be thread safe.