### PR TITLE
Fix World.AddRange with a Span<object> not adding the components after the archetype move

### DIFF
--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1247,7 +1247,11 @@ public partial class World
             newArchetype = GetOrCreate(oldArchetype.Types.Add(newComponents));
         }
 
-        Move(entity, oldArchetype, newArchetype, out _);
+        Move(entity, oldArchetype, newArchetype, out var slot);
+        foreach (var cmp in components)
+        {
+            newArchetype.Set(ref slot, cmp);
+        }
     }
 
 


### PR DESCRIPTION
Missed this in https://github.com/genaray/Arch/pull/92
Checked the rest of the Add and AddRange methods and they look correct