### PR TITLE
Make Entity and EntityRef ctors public

### DIFF
--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -147,7 +147,7 @@ public readonly struct Entity : IEquatable<Entity>
     /// <param name="id">Its unique id.</param>
     /// <param name="worldId">Its <see cref="World"/> id.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal Entity(int id, int worldId)
+    public Entity(int id, int worldId)
     {
         Id = id;
         WorldId = worldId;
@@ -255,7 +255,7 @@ public readonly struct EntityReference
     /// </summary>
     /// <param name="entity">The referenced <see cref="Entity"/>.</param>
     /// <param name="version">Its version.</param>
-    internal EntityReference(in Entity entity, in int version)
+    public EntityReference(in Entity entity, in int version)
     {
         Entity = entity;
         Version = version;


### PR DESCRIPTION
Sometimes I have the entity id / version / world id and I want to make an `Entity` or `EntityRef` from them, but I can't because the constructors are `internal`. This PR makes them `public`.

The context for this is that I wanted to make my own entity handle struct which is null when default-constructed:

```C#
struct MyHandle {
  int EntityIdPlusOne;
  int WorldId;
  int VersionPlusOne;
  Entity Entity => ??? // Need constructor
}
```