### PR TITLE
Move if EVENTS preprocessor to the event methods

### DIFF
--- a/src/Arch.SourceGen/Fundamentals/Create.cs
+++ b/src/Arch.SourceGen/Fundamentals/Create.cs
@@ -57,12 +57,10 @@ public static class CreateExtensions
                 EntityInfo.Add(entity.Id, recycled.Version, archetype, slot);
 
                 Size++;
-            #if EVENTS
                 OnEntityCreated(in entity);
 
                 {{addEvents}}
-                {{setEvents.ToString().TrimEnd()}}
-            #endif
+                {{setEvents}}
                 return entity;
             }
             """;

--- a/src/Arch.SourceGen/Fundamentals/Set.cs
+++ b/src/Arch.SourceGen/Fundamentals/Set.cs
@@ -149,9 +149,7 @@ public static class SetExtensions
                 var slot = EntityInfo.GetSlot(entity.Id);
                 var archetype = EntityInfo.GetArchetype(entity.Id);
                 archetype.Set<{{generics}}>(ref slot, {{insertParams}});
-            #if EVENTS
-                {{events.ToString().TrimEnd()}}
-            #endif
+                {{events}}
             }
             """;
 

--- a/src/Arch.SourceGen/Fundamentals/StructuralChanges.cs
+++ b/src/Arch.SourceGen/Fundamentals/StructuralChanges.cs
@@ -50,10 +50,8 @@ public static class StructuralChangesExtensions
 
                 Move(entity, oldArchetype, newArchetype, out var newSlot);
                 newArchetype.Set<{{generics}}>(ref newSlot, {{inParameters}});
-            #if EVENTS
                 {{addEvents}}
-                {{setEvents.ToString().TrimEnd()}}
-            #endif
+                {{setEvents}}
             }
             """;
 
@@ -103,9 +101,7 @@ public static class StructuralChangesExtensions
                     newArchetype = GetOrCreate(oldArchetype.Types.Remove({{types}}));
 
                 Move(entity, oldArchetype, newArchetype, out _);
-            #if EVENTS
-                {{events.ToString().TrimEnd()}}
-            #endif
+                {{events}}
             }
             """;
 

--- a/src/Arch.Tests/EventTest.cs
+++ b/src/Arch.Tests/EventTest.cs
@@ -1,5 +1,4 @@
-﻿#if EVENTS
-using Arch.Core;
+﻿using Arch.Core;
 
 namespace Arch.Tests;
 
@@ -17,6 +16,10 @@ public class EventTest
     [Test]
     public void EntityEventsTest()
     {
+#if !EVENTS
+        Assert.Ignore("Events are not enabled");
+        return;
+#else
         var asserter = new EventAsserter();
 
         _world.SubscribeEntityCreated((in Entity entity) => asserter.Created.Add(entity));
@@ -97,6 +100,7 @@ public class EventTest
         _world.SetRange(entity, new object[] { new EventTestComponentOne(), new EventTestComponentTwo() });
         asserter.AssertEvents(compOneSet: 1, compTwoSet: 1);
         asserter.Clear();
+#endif
     }
 
     private class EventAsserter
@@ -150,4 +154,3 @@ public class EventTest
     {
     }
 }
-#endif

--- a/src/Arch/Core/Events/EventHandlers.cs
+++ b/src/Arch/Core/Events/EventHandlers.cs
@@ -1,7 +1,5 @@
-﻿
-namespace Arch.Core.Events;
+﻿namespace Arch.Core.Events;
 
-#if EVENTS
 /// <summary>
 ///     A delegate called once a new <see cref="Entity"/> was created.
 /// </summary>
@@ -32,4 +30,3 @@ internal delegate void ComponentSetHandler(in Entity entity, in object comp);
 ///     A delegate called once a component was removed from a specific <see cref="Entity"/>.
 /// </summary>
 public delegate void ComponentRemovedHandler(in Entity entity);
-#endif

--- a/src/Arch/Core/Events/EventTypeRegistry.cs
+++ b/src/Arch/Core/Events/EventTypeRegistry.cs
@@ -1,14 +1,11 @@
-﻿
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Threading;
 
 namespace Arch.Core.Events;
 
-#if EVENTS
-
 /// <summary>
 ///     The <see cref="EventTypeRegistry"/> class
-///     acts as a static class storing and managing the <see cref="EventType{T}"/>s. 
+///     acts as a static class storing and managing the <see cref="EventType{T}"/>s.
 /// </summary>
 internal static class EventTypeRegistry
 {
@@ -16,27 +13,26 @@ internal static class EventTypeRegistry
     ///     The TypeId of the next event.
     /// </summary>
     internal static int NextEventTypeId = -1;
-    
+
     /// <summary>
-    ///     A <see cref="Dictionary{TKey,TValue}"/> mapping all EventTypes to their id. 
+    ///     A <see cref="Dictionary{TKey,TValue}"/> mapping all EventTypes to their id.
     /// </summary>
     internal static readonly ConcurrentDictionary<Type, int> EventIds = new();
 }
 
 /// <summary>
 ///     The <see cref="EventType{T}"/> class
-///     acts as a compile time static class to store meta data for an registered event. 
+///     acts as a compile time static class to store meta data for an registered event.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 internal static class EventType<T>
 {
-    
     /// <summary>
     ///     The Id of this <see cref="EventType{T}"/>.
     /// </summary>
     // ReSharper disable once StaticMemberInGenericType
     internal static readonly int Id;
-    
+
     /// <summary>
     ///     Creates a new instance of the <see cref="EventType{T}"/> class.
     /// </summary>
@@ -46,4 +42,3 @@ internal static class EventType<T>
         EventTypeRegistry.EventIds.TryAdd(typeof(T), Id);
     }
 }
-#endif

--- a/src/Arch/Core/Events/Events.cs
+++ b/src/Arch/Core/Events/Events.cs
@@ -1,7 +1,5 @@
-﻿
-namespace Arch.Core.Events;
+﻿namespace Arch.Core.Events;
 
-#if EVENTS
 /// <summary>
 ///     The <see cref="Events"/> class
 ///     acts as a storage for all registered event handlers and stores them properly in lists.
@@ -15,11 +13,10 @@ internal class Events
 
 /// <summary>
 ///     The <see cref="Events{T}"/> class
-///     acts as a storage for generic events and stores them in specified lists. 
+///     acts as a storage for generic events and stores them in specified lists.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 internal class Events<T> : Events
 {
     internal readonly List<ComponentSetHandler<T>> ComponentSetHandlers = new();
 }
-#endif

--- a/src/Arch/Core/Events/World.Events.cs
+++ b/src/Arch/Core/Events/World.Events.cs
@@ -1,7 +1,5 @@
 ﻿using Arch.Core.Events;
 
-#if EVENTS
-
 // ReSharper disable once CheckNamespace
 namespace Arch.Core;
 
@@ -18,7 +16,9 @@ public partial class World
     /// <param name="handler">The delegate to call.</param>
     public void SubscribeEntityCreated(EntityCreatedHandler handler)
     {
+#if EVENTS
         _entityCreatedHandlers.Add(handler);
+#endif
     }
 
     /// <summary>
@@ -27,7 +27,9 @@ public partial class World
     /// <param name="handler">The delegate to call.</param>
     public void SubscribeEntityDestroyed(EntityDestroyedHandler handler)
     {
+#if EVENTS
         _entityDestroyedHandlers.Add(handler);
+#endif
     }
 
     /// <summary>
@@ -38,8 +40,10 @@ public partial class World
     /// <typeparam name="T">The component type.</typeparam>
     public void SubscribeComponentAdded<T>(ComponentAddedHandler handler)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         events.ComponentAddedHandlers.Add(handler);
+#endif
     }
 
     /// <summary>
@@ -50,6 +54,7 @@ public partial class World
     /// <typeparam name="T">The component type.</typeparam>
     public void SubscribeComponentSet<T>(ComponentSetHandler<T> handler)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         events.ComponentSetHandlers.Add(handler);
         events.NonGenericComponentSetHandlers.Add((in Entity entity, in object comp) =>
@@ -57,6 +62,7 @@ public partial class World
             ref var compGeneric = ref Unsafe.As<object, T>(ref Unsafe.AsRef(comp));
             handler(entity, in compGeneric);
         });
+#endif
     }
 
     /// <summary>
@@ -67,8 +73,10 @@ public partial class World
     /// <typeparam name="T">The component type.</typeparam>
     public void SubscribeComponentRemoved<T>(ComponentRemovedHandler handler)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         events.ComponentRemovedHandlers.Add(handler);
+#endif
     }
 
     /// <summary>
@@ -78,10 +86,12 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnEntityCreated(in Entity entity)
     {
+#if EVENTS
         for (var i = 0; i < _entityCreatedHandlers.Count; i++)
         {
             _entityCreatedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -91,10 +101,12 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnEntityDestroyed(in Entity entity)
     {
+#if EVENTS
         for (var i = 0; i < _entityDestroyedHandlers.Count; i++)
         {
             _entityDestroyedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -105,11 +117,13 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentAdded<T>(in Entity entity)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         for (var i = 0; i < events.ComponentAddedHandlers.Count; i++)
         {
             events.ComponentAddedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -120,16 +134,18 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentAdded(in Entity entity, Type compType)
     {
+#if EVENTS
         var events = GetEvents(compType);
         if (events == null)
         {
             return;
         }
-        
+
         for (var i = 0; i < events.ComponentAddedHandlers.Count; i++)
         {
             events.ComponentAddedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -141,11 +157,13 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentSet<T>(in Entity entity, in T comp)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         for (var i = 0; i < events.ComponentSetHandlers.Count; i++)
         {
             events.ComponentSetHandlers[i](in entity, in comp);
         }
+#endif
     }
 
     /// <summary>
@@ -156,16 +174,18 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentSet(in Entity entity, in object comp)
     {
+#if EVENTS
         var events = GetEvents(comp.GetType());
         if (events == null)
         {
             return;
         }
-        
+
         for (var i = 0; i < events.NonGenericComponentSetHandlers.Count; i++)
         {
             events.NonGenericComponentSetHandlers[i](in entity, in comp);
         }
+#endif
     }
 
     /// <summary>
@@ -176,11 +196,13 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentRemoved<T>(in Entity entity)
     {
+#if EVENTS
         ref readonly var events = ref GetEvents<T>();
         for (var i = 0; i < events.ComponentRemovedHandlers.Count; i++)
         {
             events.ComponentRemovedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -191,16 +213,18 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnComponentRemoved(in Entity entity, Type compType)
     {
+#if EVENTS
         var events = GetEvents(compType);
         if (events == null)
         {
             return;
         }
-        
+
         for (var i = 0; i < events.ComponentRemovedHandlers.Count; i++)
         {
             events.ComponentRemovedHandlers[i](in entity);
         }
+#endif
     }
 
     /// <summary>
@@ -237,7 +261,7 @@ public partial class World
         {
             return null;
         }
-        
+
         if (index >= _compEvents.Length)
         {
             Array.Resize(ref _compEvents, (index * 2) + 1);
@@ -251,4 +275,3 @@ public partial class World
         return events;
     }
 }
-#endif

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -163,7 +163,6 @@ public static class WorldExtensions
             var type = Component.GetComponentType(components[index]);
             spanBitSet.SetBit(type.Id);
 #if EVENTS
-            // TODO replace this when EventType and ComponentType are merged
             componentTypes[index] = type.Type;
 #endif
         }

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -231,9 +231,7 @@ public partial class World : IDisposable
         // Map
         EntityInfo.Add(entity.Id, recycled.Version, archetype, slot);
         Size++;
-#if EVENTS
         OnEntityCreated(in entity);
-#endif
         return entity;
     }
 
@@ -288,9 +286,7 @@ public partial class World : IDisposable
         RecycledIds.Enqueue(new RecycledEntity(entity.Id, unchecked(entityInfo.Version+1)));
         Size--;
 
-#if EVENTS
         OnEntityDestroyed(in entity);
-#endif
     }
 
     /// <summary>
@@ -794,9 +790,7 @@ public partial class World
         var slot = EntityInfo.GetSlot(entity.Id);
         var archetype = EntityInfo.GetArchetype(entity.Id);
         archetype.Set(ref slot, in cmp);
-#if EVENTS
         OnComponentSet(in entity, in cmp);
-#endif
     }
 
     /// <summary>
@@ -922,9 +916,7 @@ public partial class World
         }
 
         Move(entity, oldArchetype, newArchetype, out _);
-#if EVENTS
         OnComponentAdded<T>(in entity);
-#endif
     }
 
     /// <summary>
@@ -954,11 +946,9 @@ public partial class World
         }
 
         Move(entity, oldArchetype, newArchetype, out var slot);
-        newArchetype.Set(ref slot, cmp);
-#if EVENTS
         OnComponentAdded<T>(in entity);
+        newArchetype.Set(ref slot, cmp);
         OnComponentSet(in entity, in cmp);
-#endif
     }
 
 
@@ -988,9 +978,7 @@ public partial class World
         }
 
         Move(entity, oldArchetype, newArchetype, out _);
-#if EVENTS
         OnComponentRemoved<T>(in entity);
-#endif
     }
 }
 
@@ -1009,9 +997,7 @@ public partial class World
     {
         var entitySlot = EntityInfo.GetEntitySlot(entity.Id);
         entitySlot.Archetype.Set(ref entitySlot.Slot, cmp);
-#if EVENTS
         OnComponentSet(in entity, in cmp);
-#endif
     }
 
     /// <summary>
@@ -1026,9 +1012,7 @@ public partial class World
         foreach (var cmp in components)
         {
             entitySlot.Archetype.Set(ref entitySlot.Slot, cmp);
-#if EVENTS
             OnComponentSet(in entity, in cmp);
-#endif
         }
     }
 
@@ -1161,21 +1145,18 @@ public partial class World
 
         // Create a span bitset, doing it local saves us headache and gargabe
         var spanBitSet = new SpanBitSet(stack);
-        spanBitSet.SetBit(Component.GetComponentType(cmp.GetType()).Id);
+        var cmpType = cmp.GetType();
+        spanBitSet.SetBit(Component.GetComponentType(cmpType).Id);
 
         if (!TryGetArchetype(spanBitSet.GetHashCode(), out var newArchetype))
         {
-            newArchetype = GetOrCreate(oldArchetype.Types.Add(cmp.GetType()));
+            newArchetype = GetOrCreate(oldArchetype.Types.Add(cmpType));
         }
 
         Move(entity, oldArchetype, newArchetype, out var slot);
-#if EVENTS
-        OnComponentAdded(in entity, cmp.GetType());
-#endif
+        OnComponentAdded(in entity, cmpType);
         newArchetype.Set(ref slot, cmp);
-#if EVENTS
         OnComponentSet(in entity, cmp);
-#endif
     }
 
     /// <summary>
@@ -1223,9 +1204,7 @@ public partial class World
         foreach (var cmp in components)
         {
             newArchetype.Set(ref slot, cmp);
-#if EVENTS
             OnComponentSet(in entity, in cmp);
-#endif
         }
     }
 
@@ -1255,9 +1234,7 @@ public partial class World
         }
 
         Move(entity, oldArchetype, newArchetype, out _);
-#if EVENTS
         OnComponentRemoved(in entity, type.Type);
-#endif
     }
 
     /// <summary>
@@ -1289,12 +1266,10 @@ public partial class World
         }
 
         Move(entity, oldArchetype, newArchetype, out _);
-#if EVENTS
         foreach (var type in types)
         {
             OnComponentRemoved(in entity, type.Type);
         }
-#endif
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/genaray/Arch/issues/104
Some calls still contain the preprocessor since they do more than just call the event method.
Using [Conditional("EVENTS")] instead does not seem to work.