### PR TITLE
Fix: Command Buffer accessing a component by entity id

### DIFF
--- a/src/Arch/CommandBuffer/CommandBuffer.cs
+++ b/src/Arch/CommandBuffer/CommandBuffer.cs
@@ -329,7 +329,7 @@ public class CommandBuffer : IDisposable
                 }
 
                 var chunkArray = chunk.GetArray(sparseArray.Type);
-                Array.Copy(sparseArray.Components, id, chunkArray, chunkIndex, 1);
+                Array.Copy(sparseArray.Components, sparseArray.Entities[id], chunkArray, chunkIndex, 1);
             }
         }
 


### PR DESCRIPTION
**Bug in the `CommandBuffer`**
When the component was being set the index of the entity was used to reference the component. It produced an undesired behavior of copying the wrong data or just throwing an exception as the index was out of bounds.

**Solution**
Use indirect indexing via `SparseArray.Entities` instead as it contains an index of the component