### PR TITLE
Remove unnecessary ComponentType lookups

### DIFF
--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -457,7 +457,7 @@ public sealed unsafe partial class Archetype
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Has(ComponentType type)
     {
-        var id = Component.GetComponentType(type).Id;
+        var id = type.Id;
         return BitSet.IsSet(id);
     }
 

--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -310,7 +310,7 @@ public partial struct Chunk
     [Pure]
     public bool Has(ComponentType t)
     {
-        var id = Component.GetComponentType(t).Id;
+        var id = t.Id;
         if (id >= ComponentIdToArrayIndex.Length)
         {
             return false;
@@ -391,7 +391,7 @@ public partial struct Chunk
         for (var i = 0; i < sourceComponents.Length; i++)
         {
             var sourceArray = sourceComponents[i];
-            var sourceType = sourceArray.GetType().GetElementType();
+            var sourceType = (ComponentType) sourceArray.GetType().GetElementType()!;
 
             if (!destination.Has(sourceType))
             {
@@ -422,7 +422,7 @@ public partial struct Chunk
         for (var i = 0; i < sourceComponents.Length; i++)
         {
             var sourceArray = sourceComponents[i];
-            var sourceType = sourceArray.GetType().GetElementType();
+            var sourceType = (ComponentType) sourceArray.GetType().GetElementType()!;
 
             if (!destination.Has(sourceType))
             {

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -160,7 +160,7 @@ public static class WorldExtensions
 #endif
         for (var index = 0; index < components.Count; index++)
         {
-            var type = Component.GetComponentType(components[index]);
+            var type = components[index];
             spanBitSet.SetBit(type.Id);
 #if EVENTS
             componentTypes[index] = type.Type;

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1145,8 +1145,8 @@ public partial class World
 
         // Create a span bitset, doing it local saves us headache and gargabe
         var spanBitSet = new SpanBitSet(stack);
-        var cmpType = cmp.GetType();
-        spanBitSet.SetBit(Component.GetComponentType(cmpType).Id);
+        var cmpType = Component.GetComponentType(cmp.GetType());
+        spanBitSet.SetBit(cmpType.Id);
 
         if (!TryGetArchetype(spanBitSet.GetHashCode(), out var newArchetype))
         {


### PR DESCRIPTION
From https://github.com/genaray/Arch/pull/103
Some of these result in substantially better performance for single component World.Add calls.