### PR TITLE
Add bounds debug assert to Chunk.GetArray<T>

### DIFF
--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -255,6 +255,7 @@ public partial struct Chunk
     public T[] GetArray<T>()
     {
         var index = Index<T>();
+        Debug.Assert(index != -1 && index < Components.Length, $"Index is out of bounds, component {typeof(T)} with id {index} does not exist in this chunk.");
         ref var array = ref Components.DangerousGetReferenceAt(index);
         return Unsafe.As<T[]>(array);
     }


### PR DESCRIPTION
The one added in https://github.com/genaray/Arch/commit/3da792f463b924d06978ef2f914ac56e23b5c37e doesn't account for a component type that both exists and is within the bounds of the ComponentIdToArrayIndex array.
This would cause an AccessViolationException when the indexed component type is both registered (not -1) and is smaller than the maximum type tracked by the chunk, since the assert in Index<T> wouldn't be triggered in such a case.