### PR TITLE
Move archetype edge logic to the Archetype class

### DIFF
--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -125,12 +125,6 @@ public sealed partial class Archetype
     internal const int BaseSize = 16000; // 16KB Chunk size
 
     /// <summary>
-    ///     The max <see cref="ComponentType.Id"/> that <see cref="AddEdgesArray"/>
-    ///     will be used for before using <see cref="AddEdgesDict"/>.
-    /// </summary>
-    internal const int EdgesArrayMaxSize = 256;
-
-    /// <summary>
     ///     A lookup array that maps the component id to an index within the component array of a <see cref="Chunk"/> to quickly find the correct array for the component type.
     ///     Is being stored here since all <see cref="Chunks"/> share the same instance to reduce allocations.
     /// </summary>
@@ -159,7 +153,7 @@ public sealed partial class Archetype
         Size = 1;
         Capacity = 1;
 
-        AddEdges = new ArrayDictionary<Archetype>(EdgesArrayMaxSize);
+        _addEdges = new ArrayDictionary<Archetype>(EdgesArrayMaxSize);
     }
 
     /// <summary>
@@ -232,16 +226,6 @@ public sealed partial class Archetype
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => (Size * EntitiesPerChunk) - (EntitiesPerChunk - GetChunk(Size - 1).Size);
     }
-
-    /// <summary>
-    ///     Caches other <see cref="Archetype"/>s indexed by the
-    ///     <see cref="ComponentType.Id"/> that needs to be added in order to reach them.
-    ///     Those with a <see cref="ComponentType.Id"/> equal to or lower than
-    ///     <see cref="EdgesArrayMaxSize"/> are accessed through an array lookup,
-    ///     otherwise a dictionary is used.
-    /// </summary>
-    /// <remarks>The index used is <see cref="ComponentType.Id"/> minus one.</remarks>
-    internal ArrayDictionary<Archetype> AddEdges;
 
     /// <summary>
     ///     Adds an <see cref="Arch.Core.Entity"/> to the <see cref="Archetype"/> and offloads it to a <see cref="Chunk"/>.

--- a/src/Arch/Core/Edges/Archetype.Edges.cs
+++ b/src/Arch/Core/Edges/Archetype.Edges.cs
@@ -48,7 +48,7 @@ public partial class Archetype
     ///     cache if it did not exist.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ref Archetype AddOrGetAddEdge(int index, [UnscopedRef] out bool exists)
+    internal ref Archetype CreateOrGetAddEdge(int index, [UnscopedRef] out bool exists)
     {
         return ref _addEdges.AddOrGet(index, out exists);
     }

--- a/src/Arch/Core/Edges/Archetype.Edges.cs
+++ b/src/Arch/Core/Edges/Archetype.Edges.cs
@@ -1,0 +1,72 @@
+﻿using Arch.Core.Utils;
+
+namespace Arch.Core;
+
+public partial class Archetype
+{
+    /// <summary>
+    ///     The max <see cref="ComponentType.Id"/> that <see cref="_addEdges"/>
+    ///     will use for its array storage before using a dictionary.
+    /// </summary>
+    private const int EdgesArrayMaxSize = 256;
+
+    /// <summary>
+    ///     Caches other <see cref="Archetype"/>s indexed by the
+    ///     <see cref="ComponentType.Id"/> that needs to be added in order to reach them.
+    ///     Those with a <see cref="ComponentType.Id"/> equal to or lower than
+    ///     <see cref="EdgesArrayMaxSize"/> are accessed through an array lookup,
+    ///     otherwise a dictionary is used.
+    /// </summary>
+    /// <remarks>The index used is <see cref="ComponentType.Id"/> minus one.</remarks>
+    private readonly ArrayDictionary<Archetype> _addEdges;
+
+    /// <summary>
+    ///     Tries to get a cached archetype that is reached through adding a component
+    ///     type to this archetype.
+    /// </summary>
+    /// <param name="index">
+    ///     The index of the archetype in the cache, <see cref="ComponentType.Id"/> - 1
+    /// </param>
+    /// <param name="archetype">The archetype to cache.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void CreateAddEdge(int index, Archetype archetype)
+    {
+        _addEdges.Set(index, archetype);
+    }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    ///     Gets a reference to a cached archetype that is reached through adding a
+    ///     component type to this archetype.
+    /// </summary>
+    /// <param name="index">
+    ///     The index of the archetype in the cache, <see cref="ComponentType.Id"/> - 1
+    /// </param>
+    /// <param name="exists">True if the cached archetype existed, false otherwise.</param>
+    /// <returns>
+    ///     A reference to the archetype, or a null reference to the created slot in the
+    ///     cache if it did not exist.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref Archetype AddOrGetAddEdge(int index, [UnscopedRef] out bool exists)
+    {
+        return ref _addEdges.AddOrGet(index, out exists);
+    }
+#endif
+
+    /// <summary>
+    ///     Tries to get a cached archetype that is reached through adding a component
+    ///     type to this archetype.
+    /// </summary>
+    /// <param name="index">
+    ///     The index of the archetype in the cache, <see cref="ComponentType.Id"/> - 1
+    /// </param>
+    /// <param name="archetype">The cached archetype if it exists, null otherwise.</param>
+    /// <returns>True if the archetype exists, false otherwise.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetAddEdge(int index, [NotNullWhen(true)] out Archetype? archetype)
+    {
+        archetype = _addEdges.AddOrGet(index, out var exists);
+        return exists;
+    }
+}

--- a/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
+++ b/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
@@ -105,15 +105,12 @@ internal static class ArrayExtensions
     /// <typeparam name="T">The element type of the array.</typeparam>
     /// <returns>The element at that index. May be null.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static ref T GetOrResize<T>(ref T[] array, int index, out bool exists, int? maxSize = null)
+    internal static ref T GetOrResize<T>(ref T[] array, int index, int? maxSize = null)
     {
         if (index < array.Length)
         {
-            exists = true;
             return ref array[index];
         }
-
-        exists = false;
 
         if (maxSize == null)
         {

--- a/src/Arch/Core/Utils/ArrayDictionary.cs
+++ b/src/Arch/Core/Utils/ArrayDictionary.cs
@@ -2,7 +2,7 @@
 
 namespace Arch.Core.Utils;
 
-public class ArrayDictionary<TValue>
+internal class ArrayDictionary<TValue>
 {
     /// <summary>
     ///     Stores <see cref="TValue"/>s with an index smaller than
@@ -26,56 +26,84 @@ public class ArrayDictionary<TValue>
     /// </summary>
     private readonly int _maxArraySize;
 
-    /// <summary>
-    ///     The delegate type to call when adding an element that does not already exist.
-    /// </summary>
-    /// <typeparam name="TData">The data to pass to the delegate.</typeparam>
-    public delegate TValue Create<TData>(TData data);
-
-    public ArrayDictionary(int maxArraySize)
+    internal ArrayDictionary(int maxArraySize)
     {
         _array = Array.Empty<TValue>();
         _dictionary = new Dictionary<int, TValue>(0);
         _maxArraySize = maxArraySize;
     }
 
+#if NET5_0_OR_GREATER
+    /// <summary>
+    ///     Gets a reference to an element in this collection by its index.
+    ///     If the index is smaller than <see cref="_maxArraySize"/>
+    ///     <see cref="_array"/> is used, otherwise <see cref="_dictionary"/> is used.
+    /// </summary>
+    /// <param name="index">The index of the value to get.</param>
+    /// <param name="exists">Whether or not the value existed in this collection.</param>
+    /// <returns>A ref to the value, with a default value if it did not exist.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public TValue GetOrAdd<TData>(int index, in Create<TData> create, in TData data) where TData : struct
+    internal ref TValue AddOrGet(int index, [UnscopedRef] out bool exists)
     {
         Debug.Assert(index >= 0);
 
         if (index < _maxArraySize)
         {
-            ref var value = ref ArrayExtensions.GetOrResize(ref _array, index, out var exists, _maxArraySize);
-            if (!exists)
-            {
-                value = create(data);
-            }
-
-            return value;
+            ref var value = ref ArrayExtensions.GetOrResize(ref _array, index, _maxArraySize);
+            exists = !Equals(value, default(TValue));
+            return ref value;
         }
-#if NET5_0_OR_GREATER
         else
         {
-            ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(_dictionary, index, out var exists);
-            if (!exists)
-            {
-                value = create(data);
-            }
-
-            return value!;
+            return ref CollectionsMarshal.GetValueRefOrAddDefault(_dictionary, index, out exists)!;
         }
+    }
 #else
-        else
-        {
-            if (!_dictionary.TryGetValue(index, out var value))
-            {
-                value = create(data);
-                _dictionary[index] = value;
-            }
+    /// <summary>
+    ///     Gets an element in this collection by its index.
+    ///     If the index is smaller than <see cref="_maxArraySize"/>
+    ///     <see cref="_array"/> is used, otherwise <see cref="_dictionary"/> is used.
+    /// </summary>
+    /// <param name="index">The index of the value to get.</param>
+    /// <param name="exists">Whether or not the value existed in this collection.</param>
+    /// <returns>The value, with a default value if it did not exist.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal TValue AddOrGet(int index, out bool exists)
+    {
+        Debug.Assert(index >= 0);
 
+        if (index < _maxArraySize)
+        {
+            ref var value = ref ArrayExtensions.GetOrResize(ref _array, index, _maxArraySize);
+            exists = !Equals(value, default(TValue));
             return value;
         }
+        else
+        {
+            exists = _dictionary.TryGetValue(index, out var value);
+            return value;
+        }
+    }
 #endif
+
+    /// <summary>
+    ///     Sets an element in this collection by <see cref="index"/>.
+    /// </summary>
+    /// <param name="index">The index of the <see cref="value"/> to set.</param>
+    /// <param name="value">The value to set at <see cref="index"/></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void Set(int index, in TValue value)
+    {
+        Debug.Assert(index >= 0);
+
+        if (index < _maxArraySize)
+        {
+            ref var arrayValue = ref ArrayExtensions.GetOrResize(ref _array, index, _maxArraySize);
+            arrayValue = value;
+        }
+        else
+        {
+            _dictionary[index] = value;
+        }
     }
 }

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -912,7 +912,7 @@ public partial class World
         var edgeIndex = type.Id - 1;
 
 #if NET5_0_OR_GREATER
-        newArchetype = oldArchetype.AddOrGetAddEdge(edgeIndex, out var exists);
+        newArchetype = oldArchetype.CreateOrGetAddEdge(edgeIndex, out var exists);
         if (!exists)
         {
             newArchetype = GetOrCreate(oldArchetype.Types.Add(type));
@@ -1146,7 +1146,7 @@ public partial class World
         var edgeIndex = type.Id - 1;
 
 #if NET5_0_OR_GREATER
-        var newArchetype = oldArchetype.AddOrGetAddEdge(edgeIndex, out var exists);
+        var newArchetype = oldArchetype.CreateOrGetAddEdge(edgeIndex, out var exists);
         if (!exists)
         {
             newArchetype = GetOrCreate(oldArchetype.Types.Add(type));


### PR DESCRIPTION
Closes https://github.com/genaray/Arch/issues/115

This PR also fixes a bug where archetype edges would sometimes not be added if the array had already been resized to be bigger than the new component id.
Two paths are necessary for netstandard2.0, as it is not possible to get a ref from a dictionary before .NET 5.
ArrayDictionary is made internal as well, since that is a data structure intended to be used by Arch only.
Remove edges will be implemented later as well, where it caches the resulting archetype from component removals.