### PR TITLE
Fix archetypes breaking after having more than 256 of them

### DIFF
--- a/src/Arch/Core/Edges/World.Edges.cs
+++ b/src/Arch/Core/Edges/World.Edges.cs
@@ -8,7 +8,7 @@ public partial class World
 
     /// <summary>
     ///     Creates or returns an <see cref="Archetype"/> based on the old one with one additional component.
-    ///     Automatically creates a link between them for quick access. 
+    ///     Automatically creates a link between them for quick access.
     /// </summary>
     /// <param name="type">The new <see cref="ComponentType"/> that additionally forms a new <see cref="Archetype"/> with the old components of the old archetype.</param>
     /// <param name="oldArchetype">The old <see cref="Archetype"/>.</param>
@@ -16,9 +16,9 @@ public partial class World
     private Archetype GetOrCreateArchetypeByEdge(in ComponentType type, Archetype oldArchetype)
     {
         var edgeIndex = type.Id - 1;
-        
+
 #if NET5_0_OR_GREATER
-        var newArchetype = oldArchetype.CreateOrGetAddEdge(edgeIndex, out var exists);
+        ref var newArchetype = ref oldArchetype.CreateOrGetAddEdge(edgeIndex, out var exists);
         if (!exists)
         {
             newArchetype = GetOrCreate(oldArchetype.Types.Add(type));

--- a/src/Arch/Core/Utils/ArrayDictionary.cs
+++ b/src/Arch/Core/Utils/ArrayDictionary.cs
@@ -70,7 +70,7 @@ internal class ArrayDictionary<TValue>
     {
         Debug.Assert(index >= 0);
 
-        if (index < _maxArraySize)
+        if (index >= _maxArraySize)
         {
             ref var value = ref ArrayExtensions.GetOrResize(ref _array, index, _maxArraySize);
             exists = !Equals(value, default(TValue));
@@ -94,7 +94,7 @@ internal class ArrayDictionary<TValue>
     {
         Debug.Assert(index >= 0);
 
-        if (index < _maxArraySize)
+        if (index >= _maxArraySize)
         {
             ref var arrayValue = ref ArrayExtensions.GetOrResize(ref _array, index, _maxArraySize);
             arrayValue = value;


### PR DESCRIPTION
The conditions were inverted for the max size check (256).
Also ref wasn't being used when using at leasst .NET 5, which caused another error.