### PR TITLE
Vectorized Bitsets

### DIFF
--- a/src/Arch.Benchmarks/BitSetBenchmark.cs
+++ b/src/Arch.Benchmarks/BitSetBenchmark.cs
@@ -8,22 +8,44 @@ public class BitSetBenchmark
     private BitSet _firstBitset;
     private BitSet _secondBitSet;
 
+    private BitSet _firstBitSetWithPadding;
+    private BitSet _secondBitSetWithPadding;
+
+    /*
     [GlobalSetup]
     public void Setup()
     {
-        _firstBitset = new BitSet();
+        _firstBitset = new BitSet(0);
+        _firstBitset.EnablePadding = false;
         _firstBitset.SetBit(3);
         _firstBitset.SetBit(5);
-        _firstBitset.SetBit(7);
-        _firstBitset.SetBit(128);
+        //_firstBitset.SetBit(60);
+        //_firstBitset.SetBit(128);
         _firstBitset.SetBit(256);
 
-        _secondBitSet = new BitSet();
+        _secondBitSet = new BitSet(0);
+        _secondBitSet.EnablePadding = false;
         _secondBitSet.SetBit(3);
         _secondBitSet.SetBit(5);
-        _secondBitSet.SetBit(7);
-        _secondBitSet.SetBit(128);
+        //_secondBitSet.SetBit(60);
+        //_secondBitSet.SetBit(128);
         _secondBitSet.SetBit(256);
+
+        _firstBitSetWithPadding = new BitSet();
+        _firstBitSetWithPadding.EnablePadding = true;
+        _firstBitSetWithPadding.SetBit(3);
+        _firstBitSetWithPadding.SetBit(5);
+        //_firstBitSetWithPadding.SetBit(60);
+        //_firstBitSetWithPadding.SetBit(128);
+        _firstBitSetWithPadding.SetBit(256);
+
+        _secondBitSetWithPadding = new BitSet();
+        _secondBitSetWithPadding.EnablePadding = true;
+        _secondBitSetWithPadding.SetBit(3);
+        _secondBitSetWithPadding.SetBit(5);
+        //_secondBitSetWithPadding.SetBit(60);
+        //_secondBitSetWithPadding.SetBit(128);
+        _secondBitSetWithPadding.SetBit(256);
     }
 
     [Benchmark(Baseline = true)]
@@ -35,6 +57,6 @@ public class BitSetBenchmark
     [Benchmark]
     public void Vectorized()
     {
-        //_firstBitset.AllVectorized(_secondBitSet);
-    }
+        _firstBitSetWithPadding.AllVectorized(_secondBitSetWithPadding);
+    }*/
 }

--- a/src/Arch.Tests/BitSetTest.cs
+++ b/src/Arch.Tests/BitSetTest.cs
@@ -115,23 +115,27 @@ public class BitSetTest
 
     /// <summary>
     ///     Checks <see cref="BitSet"/> none.
+    /// <param name="values">The values being set or cleared.</param>
+    /// <param name="multiplier">The multiplier for the passed values. Mainly for vectorization-testing to increase the set bits.</param>
     /// </summary>
     [Test]
-    public void BitsetNone()
+    [TestCase(new []{5,6,25,38,4}, 1)]
+    [TestCase(new []{5,6,25,38,4}, 100)]
+    public void BitsetNone(int[] values, int multiplier)
     {
         var bitSet1 = new BitSet();
-        bitSet1.SetBit(5);
-        bitSet1.SetBit(6);
+        bitSet1.SetBit(values[0] * multiplier);
+        bitSet1.SetBit(values[1] * multiplier);
         var bitSet2 = new BitSet();
-        bitSet2.SetBit(25);
-        bitSet2.SetBit(38);
+        bitSet2.SetBit(values[2] * multiplier);
+        bitSet2.SetBit(values[3] * multiplier);
 
         // None of bitset2 is in bitset1
         var allResult = bitSet2.None(bitSet1);
         That(allResult, Is.EqualTo(true));
 
         // One of bitset2 is in bitset1
-        bitSet2.SetBit(5);
+        bitSet2.SetBit(values[0] * multiplier);
         allResult = bitSet2.None(bitSet1);
         That(allResult, Is.EqualTo(false));
 
@@ -139,10 +143,10 @@ public class BitSetTest
         bitSet1.ClearAll();
         bitSet2.ClearAll();
 
-        bitSet1.SetBit(5);
-        bitSet1.SetBit(4);
-        bitSet2.SetBit(5);
-        bitSet2.SetBit(4);
+        bitSet1.SetBit(values[0] * multiplier);
+        bitSet1.SetBit(values[4] * multiplier);
+        bitSet2.SetBit(values[0] * multiplier);
+        bitSet2.SetBit(values[4] * multiplier);
 
         allResult = bitSet2.None(bitSet1);
         That(allResult, Is.EqualTo(false));

--- a/src/Arch.Tests/BitSetTest.cs
+++ b/src/Arch.Tests/BitSetTest.cs
@@ -153,15 +153,57 @@ public class BitSetTest
     }
 
     /// <summary>
-    ///     Checks whether different sized <see cref="BitSet"/>'s work correctly.
+    ///     Checks <see cref="BitSet"/> exclusive.
+    /// <param name="values">The values being set or cleared.</param>
+    /// <param name="multiplier">The multiplier for the passed values. Mainly for vectorization-testing to increase the set bits.</param>
     /// </summary>
     [Test]
-    public void AllWithDifferentLengthBitSet()
+    [TestCase(new []{5,6,25}, 1)]
+    [TestCase(new []{5,6,25}, 100)]
+    public void BitsetExclusive(int[] values, int multiplier)
     {
         var bitSet1 = new BitSet();
-        bitSet1.SetBit(5);
+        bitSet1.SetBit(values[0] * multiplier);
+        bitSet1.SetBit(values[1] * multiplier);
         var bitSet2 = new BitSet();
-        bitSet2.SetBit(33);
+        bitSet2.SetBit(values[0] * multiplier);
+        bitSet2.SetBit(values[1] * multiplier);
+
+        // Both are totally equal
+        var exclusive = bitSet2.Exclusive(bitSet1);
+        That(exclusive, Is.EqualTo(true));
+
+        // Bitset2 is not equal anymore
+        bitSet2.SetBit(values[2] * multiplier);
+        exclusive = bitSet2.Exclusive(bitSet1);
+        That(exclusive, Is.EqualTo(false));
+
+        // Bitset2 is back to default, but bitset1 is now different -> both differ, should be false
+        bitSet2.ClearBit(values[2] * multiplier);
+        bitSet1.SetBit(values[2] * multiplier);
+        exclusive = bitSet2.Exclusive(bitSet1);
+        That(exclusive, Is.EqualTo(false));
+
+        // Bitset2 is now the same as bitset 1 -> should be true
+        bitSet2.SetBit(values[2] * multiplier);
+        exclusive = bitSet2.Exclusive(bitSet1);
+        That(exclusive, Is.EqualTo(true));
+    }
+
+    /// <summary>
+    ///     Checks whether different sized <see cref="BitSet"/>'s work correctly.
+    /// <param name="values">The values being set or cleared.</param>
+    /// <param name="multiplier">The multiplier for the passed values. Mainly for vectorization-testing to increase the set bits.</param>
+    /// </summary>
+    [Test]
+    [TestCase(new []{5,33}, 1)]
+    [TestCase(new []{5,33}, 100)]
+    public void AllWithDifferentLengthBitSet(int[] values, int multiplier)
+    {
+        var bitSet1 = new BitSet();
+        bitSet1.SetBit(values[0] * multiplier);
+        var bitSet2 = new BitSet();
+        bitSet2.SetBit(values[1] * multiplier);
 
         var allResult = bitSet2.All(bitSet1);
         var anyResult = bitSet2.Any(bitSet1);

--- a/src/Arch.Tests/BitSetTest.cs
+++ b/src/Arch.Tests/BitSetTest.cs
@@ -61,6 +61,7 @@ public class BitSetTest
         var bitSet1 = new BitSet();
         bitSet1.SetBit(5);
         bitSet1.SetBit(6);
+
         var bitSet2 = new BitSet();
         bitSet2.SetBit(5);
         bitSet2.SetBit(6);

--- a/src/Arch.Tests/BitSetTest.cs
+++ b/src/Arch.Tests/BitSetTest.cs
@@ -4,13 +4,13 @@ using static NUnit.Framework.Assert;
 
 namespace Arch.Tests;
 
+
 /// <summary>
 ///     Checks <see cref="BitSet"/> and HashCode related methods.
 /// </summary>
 [TestFixture]
 public class BitSetTest
 {
-
     /// <summary>
     ///     Checks if <see cref="ComponentType"/>-Arrays with same elements but in different order result in the same hash.
     /// </summary>
@@ -54,53 +54,61 @@ public class BitSetTest
 
     /// <summary>
     ///     Checks <see cref="BitSet"/> all.
+    /// <param name="values">The values being set.</param>
+    /// <param name="multiplier">The multiplier for the passed values. Mainly for vectorization-testing to increase the set bits.</param>
     /// </summary>
     [Test]
-    public void BitsetAll()
+    [TestCase(new []{5,6,7}, 1)]    // Sets bit 5,6,7
+    [TestCase(new []{5,6,7}, 100)]  // Sets bit 500,600,700
+    public void BitsetAll(int[] values, int multiplier)
     {
         var bitSet1 = new BitSet();
-        bitSet1.SetBit(5);
-        bitSet1.SetBit(6);
+        bitSet1.SetBit(values[0] * multiplier);
+        bitSet1.SetBit(values[1] * multiplier);
 
         var bitSet2 = new BitSet();
-        bitSet2.SetBit(5);
-        bitSet2.SetBit(6);
+        bitSet2.SetBit(values[0] * multiplier);
+        bitSet2.SetBit(values[1] * multiplier);
 
         // ALl fit
         var allResult = bitSet2.All(bitSet1);
         That(allResult, Is.EqualTo(true));
 
-        bitSet2.SetBit(7);
+        bitSet2.SetBit(values[2] * multiplier);
         allResult = bitSet2.All(bitSet1);
         That(allResult, Is.EqualTo(false));
     }
 
     /// <summary>
     ///     Checks <see cref="BitSet"/> any.
+    /// <param name="values">The values being set or cleared.</param>
+    /// <param name="multiplier">The multiplier for the passed values. Mainly for vectorization-testing to increase the set bits.</param>
     /// </summary>
     [Test]
-    public void BitsetAny()
+    [TestCase(new []{5,6,35,36,37}, 1)]
+    [TestCase(new []{5,6,35,36,37}, 100)]
+    public void BitsetAny(int[] values, int multiplier)
     {
         var bitSet1 = new BitSet();
-        bitSet1.SetBit(5);
-        bitSet1.SetBit(6);
-        bitSet1.SetBit(35);
-        bitSet1.SetBit(36);
+        bitSet1.SetBit(values[0] * multiplier);
+        bitSet1.SetBit(values[1] * multiplier);
+        bitSet1.SetBit(values[2] * multiplier);
+        bitSet1.SetBit(values[3] * multiplier);
         var bitSet2 = new BitSet();
-        bitSet2.SetBit(5);
-        bitSet2.SetBit(6);
+        bitSet2.SetBit(values[0] * multiplier);
+        bitSet2.SetBit(values[1] * multiplier);
 
         // Any fit
         var allResult = bitSet2.Any(bitSet1);
         That(allResult, Is.EqualTo(true));
 
-        bitSet2.ClearBit(5);
+        bitSet2.ClearBit(values[0] * multiplier);
         allResult = bitSet2.Any(bitSet1);
         That(allResult, Is.EqualTo(true));
 
         // No fit, since there no unions
         bitSet2.ClearAll();
-        bitSet2.SetBit(37);
+        bitSet2.SetBit(values[4] * multiplier);
         allResult = bitSet2.Any(bitSet1);
         That(allResult, Is.EqualTo(false));
     }

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -324,26 +324,56 @@ public class BitSet
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Exclusive(BitSet other)
     {
-        var bits = _bits.AsSpan();
-        var otherBits = other._bits.AsSpan();
-        var count = Math.Min(_bits.Length, otherBits.Length);
+        var max = (_highestBit/sizeof(uint)/Padding)+1;
+        var min = Math.Min(Math.Min(Length, other.Length), max);
 
-        for (var i = 0; i < count; i++)
+        if (!Vector.IsHardwareAccelerated || min < Padding)
         {
-            var bit = bits[i];
-            if ((bit ^ otherBits[i]) != 0)
+            var bits = _bits.AsSpan();
+            var otherBits = other._bits.AsSpan();
+
+            // Bitwise xor, if both are not totally equal, return false
+            for (var i = 0; i < min; i++)
             {
-                return false;
+                var bit = bits[i];
+                if ((bit ^ otherBits[i]) != 0)
+                {
+                    return false;
+                }
+            }
+
+            // handle extra bits on our side that might just be all zero
+            for (var i = min; i < max; i++)
+            {
+                if (bits[i] != 0)
+                {
+                    return false;
+                }
             }
         }
-
-        // handle extra bits on our side that might just be all zero
-        var bitCount = _bits.Length;
-        for (var i = count; i < bitCount; i++)
+        else
         {
-            if (bits[i] != 0)
+            // Vectorized bitwise xor, return true since any is met
+            for (var i = 0; i < min; i += Padding)
             {
-                return false;
+                var vector = new Vector<uint>(_bits, i);
+                var otherVector = new Vector<uint>(other._bits, i);
+
+                var resultVector = Vector.Xor(vector, otherVector);
+                if (!Vector.EqualsAll(resultVector, Vector<uint>.Zero))
+                {
+                    return false;
+                }
+            }
+
+            // Handle extra bits on our side that might just be all zero.
+            for (var i = min; i < max; i += Padding)
+            {
+                var vector = new Vector<uint>(_bits, i);
+                if (!Vector.EqualsAll(vector, Vector<uint>.Zero)) // Vectors are not zero bits[0] != 0 basically
+                {
+                    return false;
+                }
             }
         }
 

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -25,7 +25,6 @@ public class BitSet
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int RequiredLength(int id)
     {
-        return (int)Math.Ceiling((float)id / BitSize);
 #if NET7_0
         return (id >> 5) + int.Sign(id & BitSize);
 #else

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -25,6 +25,7 @@ public class BitSet
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int RequiredLength(int id)
     {
+        return (int)Math.Ceiling((float)id / BitSize);
 #if NET7_0
         return (id >> 5) + int.Sign(id & BitSize);
 #else
@@ -306,13 +307,16 @@ public class BitSet
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<uint> AsSpan()
     {
-        return _bits.AsSpan();
+        var max = (_highestBit / sizeof(uint) / Padding) + 1;
+        return _bits.AsSpan(0, max);
     }
 
     /// <summary>
     ///     Copies the bits into a <see cref="Span{T}"/> and returns a slice containing the copied <see cref="_bits"/>.
     /// </summary>
-    /// <returns>The hash.</returns>
+    /// <param name="span">The <see cref="Span{T}"/> to copy into.</param>
+    /// <param name="zero">If true, it will zero the unused space from the <see cref="span"/>.</param>
+    /// <returns>The <see cref="Span{T}"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<uint> AsSpan(Span<uint> span, bool zero = true)
     {
@@ -329,7 +333,7 @@ public class BitSet
             span[index] = 0;
         }
 
-        return span[.._bits.Length];
+        return span[..length];
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -314,22 +314,6 @@ public class BitSet
         }
 
         return true;
-
-        /*
-        var bits = _bits.AsSpan();
-        var otherBits = other._bits.AsSpan();
-        var count = Math.Min(_bits.Length, otherBits.Length);
-
-        for (var i = 0; i < count; i++)
-        {
-            var bit = bits[i];
-            if ((bit & otherBits[i]) != 0)
-            {
-                return false;
-            }
-        }
-
-        return true;*/
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -102,7 +102,7 @@ public static class ComponentRegistry
     /// <summary>
     ///     Gets or sets the total number of registered components in the project.
     /// </summary>
-    public static int Size { get; private set; }
+    public static int Size { get; internal set; }
 
     /// <summary>
     ///     Adds a new <see cref="ComponentType"/> manually and registers it.
@@ -136,7 +136,15 @@ public static class ComponentRegistry
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ComponentType Add(ComponentType type)
     {
-        return Add(type.Type, type.ByteSize);
+
+        // Register and assign component id
+        _types.Add(type, type);
+
+        Size++;
+        return type;
+
+        /*
+        return Add(type.Type, type.ByteSize);*/
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/MurmurHash3.cs
+++ b/src/Arch/Core/Utils/MurmurHash3.cs
@@ -5,7 +5,7 @@ namespace Arch.Core.Utils;
 ///     The <see cref="MurmurHash3"/> class
 ///     represents a utility to calculate a MurMurHash3 used to map querys and descriptions to archetypes.
 /// </summary>
-public class MurmurHash3
+public static class MurmurHash3
 {
     /// <summary>
     ///     Calculates the hash as a 32 bit integer and returns it.
@@ -51,16 +51,16 @@ public class MurmurHash3
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static uint RotateLeft(uint x, byte r)
+    private static uint RotateLeft(uint x, byte r)
     {
-        return x << (int) r | x >> 32 - (int) r;
+        return (x << (int) r) | (x >> (32 - (int) r));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static uint FMix(uint h)
+    private static uint FMix(uint h)
     {
         h = (uint) (((int) h ^ (int) (h >> 16)) * -2048144789);
         h = (uint) (((int) h ^ (int) (h >> 13)) * -1028477387);
-        return h ^ h >> 16;
+        return h ^ (h >> 16);
     }
 }


### PR DESCRIPTION
Realistically, many projects have a large number of components that are used. Up to 100, 200 or even more depending on the scale. 

So far, such a high number of components in the `Bitset` has caused problems. These simply checked the bits with a scalar loop. For a few used components this is fast, but for many it is quite slow and noticeable.

Therefore this PR integrates vectorized `BitSet` methods to process a high number of used components faster. This is triggered only at a certain number, if the number of registered components exceeds this, the methods are executed vectorized. If they fall under it, the execution remains scalar. Since vectorization comes along with an overhead for few elements, the best of both sides is combined. 