### PR TITLE
Add support for registering arrays for AOT support

### DIFF
--- a/src/Arch/CommandBuffer/SparseSet.cs
+++ b/src/Arch/CommandBuffer/SparseSet.cs
@@ -46,7 +46,7 @@ internal class SparseArray
         Size = 0;
         Entities = new int[Capacity];
         Array.Fill(Entities, -1);
-        Components = Array.CreateInstance(type, Capacity);
+        Components = ArrayRegistry.GetArray(type, Capacity);
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ internal class SparseArray
                 Array.Fill(Entities, -1, Capacity, newLength-Capacity);
 
                 // Resize component array
-                var array = Array.CreateInstance(Type, newLength);
+                var array = ArrayRegistry.GetArray(Type, newLength);
                 Components.CopyTo(array, 0);
                 Components = array;
                 Capacity = newLength;

--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -44,7 +44,7 @@ public partial struct Chunk
         for (var index = 0; index < types.Length; index++)
         {
             var type = types[index];
-            Components[index] = Array.CreateInstance(type, Capacity);
+            Components[index] = ArrayRegistry.GetArray(type, Capacity);
         }
     }
 

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -343,7 +343,7 @@ public static class ComponentRegistry
 /// </summary>
 public static class ArrayRegistry
 {
-    private static readonly Dictionary<Type, Func<int, Array>> _createFactories = new(128);
+    private static readonly JaggedArray<Func<int, Array>> _createFactories = new(128);
 
     /// <summary>
     ///     Adds a new array type and registers it.
@@ -351,7 +351,7 @@ public static class ArrayRegistry
     /// <typeparam name="T">The type of the array.</typeparam>
     public static void Add<T>()
     {
-        _createFactories.Add(typeof(T), ArrayFactory<T>.Create);
+        _createFactories.Add(((ComponentType) typeof(T)).Id, ArrayFactory<T>.Create);
     }
 
     /// <summary>
@@ -362,7 +362,18 @@ public static class ArrayRegistry
     /// <returns>The created array.</returns>
     public static Array GetArray(Type type, int capacity)
     {
-        return _createFactories.TryGetValue(type, out var func) ? func(capacity) : Array.CreateInstance(type, capacity);
+        return GetArray((ComponentType) type, capacity);
+    }
+
+    /// <summary>
+    ///     Gets an array of the specified type and capacity. Will use the registered factory if it exists, otherwise it will create a new array using reflection.
+    /// </summary>
+    /// <param name="type">The type of the array.</param>
+    /// <param name="capacity">The capacity of the array.</param>
+    /// <returns>The created array.</returns>
+    public static Array GetArray(ComponentType type, int capacity)
+    {
+        return _createFactories.TryGetValue(type.Id, out var func) ? func(capacity) : Array.CreateInstance(type.Type, capacity);
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -339,6 +339,43 @@ public static class ComponentRegistry
 }
 
 /// <summary>
+///     Tracks all registered arrays in the project. Allows to create arrays of a specific type without reflection at runtime, if they are registered.
+/// </summary>
+public static class ArrayRegistry
+{
+    private static readonly Dictionary<Type, Func<int, Array>> _createFactories = new(128);
+
+    /// <summary>
+    ///     Adds a new array type and registers it.
+    /// </summary>
+    /// <typeparam name="T">The type of the array.</typeparam>
+    public static void Add<T>()
+    {
+        _createFactories.Add(typeof(T), ArrayFactory<T>.Create);
+    }
+
+    /// <summary>
+    ///     Gets an array of the specified type and capacity. Will use the registered factory if it exists, otherwise it will create a new array using reflection.
+    /// </summary>
+    /// <param name="type">The type of the array.</param>
+    /// <param name="capacity">The capacity of the array.</param>
+    /// <returns>The created array.</returns>
+    public static Array GetArray(Type type, int capacity)
+    {
+        return _createFactories.TryGetValue(type, out var func) ? func(capacity) : Array.CreateInstance(type, capacity);
+    }
+
+    /// <summary>
+    ///     An array factory that creates arrays of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of the array.</typeparam>
+    private static class ArrayFactory<T>
+    {
+        public static readonly Func<int, Array> Create = capacity => capacity == 0 ? Array.Empty<T>() : new T[capacity];
+    }
+}
+
+/// <summary>
 ///     The <see cref="Component{T}"/> class, provides compile time static information about a component.
 /// </summary>
 /// <typeparam name="T">Its generic type.</typeparam>

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -351,7 +351,7 @@ public static class ArrayRegistry
     /// <typeparam name="T">The type of the array.</typeparam>
     public static void Add<T>()
     {
-        _createFactories.Add(((ComponentType) typeof(T)).Id, ArrayFactory<T>.Create);
+        _createFactories.Add(Component<T>.ComponentType.Id, ArrayFactory<T>.Create);
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -360,17 +360,6 @@ public static class ArrayRegistry
     /// <param name="type">The type of the array.</param>
     /// <param name="capacity">The capacity of the array.</param>
     /// <returns>The created array.</returns>
-    public static Array GetArray(Type type, int capacity)
-    {
-        return GetArray((ComponentType) type, capacity);
-    }
-
-    /// <summary>
-    ///     Gets an array of the specified type and capacity. Will use the registered factory if it exists, otherwise it will create a new array using reflection.
-    /// </summary>
-    /// <param name="type">The type of the array.</param>
-    /// <param name="capacity">The capacity of the array.</param>
-    /// <returns>The created array.</returns>
     public static Array GetArray(ComponentType type, int capacity)
     {
         return _createFactories.TryGetValue(type.Id, out var func) ? func(capacity) : Array.CreateInstance(type.Type, capacity);


### PR DESCRIPTION
This PR adds a new ArrayRegistry class that you can use to fully support Native AOT. It would also open up the possibility of a source generator to call this for you. 

You would use this by calling `ArrayRegistry.Add<MyComponent>();` and then the chunks will try to get an array from the ArrayRegistry instead. If no component has been registered, it will default back to reflection, so no functionality is broken and you aren't forced to use this. 

Along with this change, if the user chooses to use this along with the source generators in Arch.Extended, one can achieve a fully Native AOT without ***any reflection***!