### PR TITLE
Add (local) publishing of Arch and its transitive dependencies for Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist
 /.idea/
 /.fleet/
 BenchmarkDotNet.Artifacts

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,12 +1,13 @@
 <Project>
   <Target Name="Unity"
           DependsOnTargets="Publish"
-          Condition="'$(RootNamespace.Contains(Tests))' != 'true' And '$(OutputType.Contains(Exe))' != 'true'">
+          Condition="'$(UnityPublish.Contains(true))'">
     <PropertyGroup>
       <TargetFramework>netstandard2.1</TargetFramework>
       <TargetFrameworks>netstandard2.1</TargetFrameworks>
       <Configuration>Release</Configuration>
       <UseAppHost>false</UseAppHost>
+      <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     </PropertyGroup>
   </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="Unity"
+          DependsOnTargets="Publish"
+          Condition="'$(RootNamespace.Contains(Tests))' != 'true' And '$(OutputType.Contains(Exe))' != 'true'">
+    <PropertyGroup>
+      <TargetFramework>netstandard2.1</TargetFramework>
+      <TargetFrameworks>netstandard2.1</TargetFrameworks>
+      <Configuration>Release</Configuration>
+      <UseAppHost>false</UseAppHost>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/scripts/UnityPublish.sh
+++ b/scripts/UnityPublish.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Publishes Unity release to dist/Assemblies using only netstandard2.0 and netstandard2.1
+#########################################################################################
+
+dotnet restore
+
+mkdir -p dist/Assemblies
+
+dotnet msbuild /t:Unity -p:PublishDir=`pwd`/dist/Assemblies
+
+# Unity transitively provides the below libraries. Plus, they are heavy and redistribution-restrictive.
+# All of Linq should go hence the wildcard, but System.Threading.Tasks.Extensions is fine (MIT).
+rm `pwd`/dist/Assemblies/System.Linq* `pwd`/dist/Assemblies/System.Threading.dll

--- a/scripts/UnityPublish.sh
+++ b/scripts/UnityPublish.sh
@@ -5,10 +5,12 @@
 
 dotnet restore
 
-mkdir -p dist/Assemblies
+assemblyDir="`pwd`/dist/Assemblies"
 
-dotnet msbuild /t:Unity -p:PublishDir=`pwd`/dist/Assemblies
+mkdir -p "${assemblyDir}"
+
+dotnet msbuild /t:Unity -p:PublishDir="${assemblyDir}"
 
 # Unity transitively provides the below libraries. Plus, they are heavy and redistribution-restrictive.
 # All of Linq should go hence the wildcard, but System.Threading.Tasks.Extensions is fine (MIT).
-rm `pwd`/dist/Assemblies/System.Linq* `pwd`/dist/Assemblies/System.Threading.dll
+rm "${assemblyDir}/System.Linq*" "${assemblyDir}/System.Threading.dll"

--- a/scripts/UnityPublish.sh
+++ b/scripts/UnityPublish.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Publishes Unity release to dist/Assemblies using only netstandard2.0 and netstandard2.1
+# Does NOT include source generation
 #########################################################################################
 
 dotnet restore

--- a/scripts/UnityPublish.sh
+++ b/scripts/UnityPublish.sh
@@ -10,7 +10,3 @@ assemblyDir="`pwd`/dist/Assemblies"
 mkdir -p "${assemblyDir}"
 
 dotnet msbuild /t:Unity -p:PublishDir="${assemblyDir}"
-
-# Unity transitively provides the below libraries. Plus, they are heavy and redistribution-restrictive.
-# All of Linq should go hence the wildcard, but System.Threading.Tasks.Extensions is fine (MIT).
-rm "${assemblyDir}/System.Linq*" "${assemblyDir}/System.Threading.dll"

--- a/src/Arch.SourceGen/Arch.SourceGen.csproj
+++ b/src/Arch.SourceGen/Arch.SourceGen.csproj
@@ -25,7 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="analyzers" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Arch/Arch.csproj
+++ b/src/Arch/Arch.csproj
@@ -40,6 +40,8 @@ BitSets are now vectorized, resulting in faster checks when large amounts of com
     <NoWarn>1701;1702;1591</NoWarn>
 
     <Configurations>Debug;Debug-PureECS;Debug-Events;Release;Release-PureECS;Release-Events;</Configurations>
+
+    <UnityPublish>true</UnityPublish>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Arch/Arch.csproj
+++ b/src/Arch/Arch.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
At a high level, this pull request adds a `UnityPublish.sh` script that quickly and easily generates Arch DLLs (and transitive DLLs) needed for Unity, **not** including source generation. Running `./scripts/UnityPublish.sh` publishes the files to `dist/Assemblies`. The same script could be used in further automation via a GitHub Action to produce a zipped build artifact. I recommend doing so as a follow-up pull request.

Granular changes:

* `dist` was added to the `.gitignore` to keep Unity-published files out of Git history.
* A `Directory.Build.targets` file has been added to the root directory. It is configuration for defining custom targets at the solution level which override those of the encompassed project (`csproj`) configuration because MSBuild reads it in last as opposed to all other configuration. To be clear, this is an MSBuild-specific file, hence the odd name. Using this file is the only reasonable way to force all published projects to <=`netstandard2.1` while simultaneously retaining transitive DLLs.
* An 'allow list' policy has been adopted to ensure only certain projects are published, so a `UnityPublish` property is used in the `csproj` to control whether a project is published per the condition in `Directory.Build.targets`.
* A `TargetFramework` property has been added to projects that lacked it, because the pluralized property is not enough for MSBuild. It will complain if the singular property is missing. Setting the property to `netstandard2.1` as the default should not affect multi-targeting projects as long as their target is specified while per-project building/publishing.
* For correctness, the Arch source generation project has been appropriately marked with `PrivateAssets="analyzers"`. And also...

```xml
<ItemGroup>
  <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
</ItemGroup>
```

That item group was added to the source generation for consistency with the source generation configuration in Arch.Extensions.

---

I've tested the published assemblies in a 2022.3 Unity project and they work like a dream. Let me know if there are any changes I can make to improve things. I recommend squashing the commits upon merge.

A "sister" PR is being submitted for Arch.Extended (**edit:** refer to https://github.com/genaray/Arch.Extended/pull/24).