### PR TITLE
World concurrency fixes, structural change annotations, and code cleanup

### DIFF
--- a/src/Arch.SourceGen/Fundamentals/Create.cs
+++ b/src/Arch.SourceGen/Fundamentals/Create.cs
@@ -27,6 +27,7 @@ public static class CreateExtensions
         var template =
             $$"""
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [StructuralChange]
             public Entity Create<{{generics}}>({{parameters}})
             {
                 var types = Group<{{generics}}>.Types;

--- a/src/Arch.SourceGen/Fundamentals/Group.cs
+++ b/src/Arch.SourceGen/Fundamentals/Group.cs
@@ -23,15 +23,24 @@ public static class GroupExtensions
 
         var template =
             $$"""
+            /// <inheritdoc cref="Group"/>
             public static class Group<{{generics}}>
             {
                 internal static readonly int Id;
-                internal static readonly ComponentType[] Types;
-                internal static readonly int Hash;
+            
+                /// <summary>
+                ///     The global array of <see cref="ComponentType"/> for this given type group. Must not be modified in any way.
+                /// </summary>
+                public static readonly ComponentType[] Types;
+
+                /// <summary>
+                ///     The hash code for this given type group.
+                /// </summary>
+                public static readonly int Hash;
             
                 static Group()
                 {
-                    Id = Group.Id++;
+                    Id = Interlocked.Increment(ref Group.Id);
                     Types = new ComponentType[] { {{types}} };
                     Hash = Component.GetHashCode(Types);
                 }

--- a/src/Arch.SourceGen/Fundamentals/StructuralChanges.cs
+++ b/src/Arch.SourceGen/Fundamentals/StructuralChanges.cs
@@ -31,6 +31,7 @@ public static class StructuralChangesExtensions
             $$"""
             [SkipLocalsInit]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [StructuralChange]
             public void Add<{{generics}}>(Entity entity, {{parameters}})
             {
                 var oldArchetype = EntityInfo.GetArchetype(entity.Id);
@@ -82,6 +83,7 @@ public static class StructuralChangesExtensions
             $$"""
             [SkipLocalsInit]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [StructuralChange]
             public void Remove<{{generics}}>(Entity entity)
             {
                 var oldArchetype = EntityInfo.GetArchetype(entity.Id);

--- a/src/Arch.SourceGen/Queries/AddWithQueryDescription.cs
+++ b/src/Arch.SourceGen/Queries/AddWithQueryDescription.cs
@@ -46,6 +46,7 @@ public static class AddWithQueryDescription
             $$"""
             [SkipLocalsInit]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [StructuralChange]
             public void Add<{{generics}}>(in QueryDescription queryDescription, {{parameters}})
             {
                 // BitSet to stack/span bitset, size big enough to contain ALL registered components.

--- a/src/Arch.SourceGen/Queries/RemoveWithQueryDescription.cs
+++ b/src/Arch.SourceGen/Queries/RemoveWithQueryDescription.cs
@@ -43,6 +43,7 @@ public static class RemoveWithQueryDesription
             $$"""
             [SkipLocalsInit]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [StructuralChange]
             public void Remove<{{generics}}>(in QueryDescription queryDescription)
             {
                 // BitSet to stack/span bitset, size big enough to contain ALL registered components.

--- a/src/Arch.SourceGen/QueryGenerator.cs
+++ b/src/Arch.SourceGen/QueryGenerator.cs
@@ -66,8 +66,8 @@ public class QueryGenerator : IIncrementalGenerator
             accessors.AppendLine("using System.Buffers;");
             accessors.AppendLine(
                 $$"""
-                namespace Arch.Core{
-
+                namespace Arch.Core
+                {
                     public partial struct Chunk
                     {
                         {{new StringBuilder().AppendChunkIndexes(25)}}
@@ -123,8 +123,8 @@ public class QueryGenerator : IIncrementalGenerator
 
                 }
 
-                namespace Arch.Core.Extensions{
-
+                namespace Arch.Core.Extensions
+                {
                     public static partial class EntityExtensions
                     {
                     #if !PURE_ECS
@@ -155,7 +155,7 @@ public class QueryGenerator : IIncrementalGenerator
             initializationContext.AddSource("Jobs.g.cs",
                 CSharpSyntaxTree.ParseText(jobs.ToString()).GetRoot().NormalizeWhitespace().ToFullString());
 
-            initializationContext.AddSource("Acessors.g.cs",
+            initializationContext.AddSource("Accessors.g.cs",
                 CSharpSyntaxTree.ParseText(accessors.ToString()).GetRoot().NormalizeWhitespace().ToFullString());
         });
     }

--- a/src/Arch.SourceGen/QueryGenerator.cs
+++ b/src/Arch.SourceGen/QueryGenerator.cs
@@ -18,6 +18,7 @@ public class QueryGenerator : IIncrementalGenerator
 
             var compileTimeStatics = new StringBuilder();
             compileTimeStatics.AppendLine("using System;");
+            compileTimeStatics.AppendLine("using System.Threading;");
             compileTimeStatics.AppendLine("namespace Arch.Core.Utils;");
             compileTimeStatics.AppendGroups(25);
 

--- a/src/Arch/CommandBuffer/CommandBuffer.cs
+++ b/src/Arch/CommandBuffer/CommandBuffer.cs
@@ -71,7 +71,7 @@ public class CommandBuffer : IDisposable
     ///     with the specified <see cref="Core.World"/> and an optional <paramref name="initialCapacity"/> (default: 128).
     /// </summary>
     /// <param name="world">The <see cref="World"/>.</param>
-    /// <param name="initialCapacity">The <see cref="initialCapacity"/>.</param>
+    /// <param name="initialCapacity">The initial capacity.</param>
     public CommandBuffer(World world, int initialCapacity = 128)
     {
         World = world;
@@ -215,7 +215,7 @@ public class CommandBuffer : IDisposable
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="component">The component value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Set<T>(in Entity entity, in T component = default)
+    public void Set<T>(in Entity entity, in T? component = default)
     {
         BufferedEntityInfo info;
         lock (this)
@@ -238,7 +238,7 @@ public class CommandBuffer : IDisposable
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="component">The component value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in Entity entity, in T component = default)
+    public void Add<T>(in Entity entity, in T? component = default)
     {
         BufferedEntityInfo info;
         lock (this)
@@ -277,6 +277,7 @@ public class CommandBuffer : IDisposable
     /// <summary>
     ///     Adds an list of new components to the <see cref="Entity"/> and moves it to the new <see cref="Archetype"/>.
     /// </summary>
+    /// <param name="world">The world to operate on.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="components">A <see cref="IList{T}"/> of <see cref="ComponentType"/>'s, those are added to the <see cref="Entity"/>.</param>
     [SkipLocalsInit]
@@ -424,7 +425,6 @@ public class CommandBuffer : IDisposable
             _removeTypes.Clear();
         }
 
-
         // Play back destructions.
         foreach (var cmd in Destroys)
         {
@@ -458,5 +458,6 @@ public class CommandBuffer : IDisposable
         Destroys?.Dispose();
         _addTypes?.Dispose();
         _removeTypes?.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -311,7 +311,7 @@ public sealed partial class Archetype
     /// <param name="slot">The <see cref="Slot"/> at which the component of an <see cref="Arch.Core.Entity"/> is to be set or replaced.</param>
     /// <param name="cmp">The component value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void Set<T>(ref Slot slot, in T cmp)
+    internal void Set<T>(ref Slot slot, in T? cmp)
     {
         ref var chunk = ref GetChunk(slot.ChunkIndex);
         chunk.Set(slot.Index, in cmp);
@@ -374,7 +374,7 @@ public sealed partial class Archetype
     /// <param name="component">The component value.</param>
     /// <typeparam name="T">The component type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void SetRange<T>(in Slot from, in Slot to, in T component = default)
+    internal void SetRange<T>(in Slot from, in Slot to, in T? component = default)
     {
         // Set the added component, start from the last slot and move down
         for (var chunkIndex = from.ChunkIndex; chunkIndex >= to.ChunkIndex; --chunkIndex)
@@ -488,7 +488,7 @@ public sealed unsafe partial class Archetype
     /// <param name="slot">The <see cref="Slot"/>.</param>
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal object Get(scoped ref Slot slot, ComponentType type)
+    internal object? Get(scoped ref Slot slot, ComponentType type)
     {
         ref var chunk = ref GetChunk(slot.ChunkIndex);
         return chunk.Get(slot.Index, type);
@@ -680,6 +680,7 @@ public sealed partial class Archetype
     /// <summary>
     ///     Copies an <see cref="Arch.Core.Entity"/> and all its components from a <see cref="Slot"/> within this <see cref="Archetype"/> to a <see cref="Slot"/> within another <see cref="Archetype"/> .
     /// </summary>
+    /// <param name="from">The <see cref="Archetype"/> from which the <see cref="Arch.Core.Entity"/> should move.</param>
     /// <param name="to">The <see cref="Archetype"/> into which the <see cref="Arch.Core.Entity"/> should move.</param>
     /// <param name="fromSlot">The <see cref="Slot"/> that targets the <see cref="Arch.Core.Entity"/> that should move.</param>
     /// <param name="toSlot">The <see cref="Slot"/> to which the <see cref="Arch.Core.Entity"/> should move.</param>

--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -328,7 +328,7 @@ public partial struct Chunk
     /// <returns>A component casted to an <see cref="object"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public object Get(int index, ComponentType type)
+    public object? Get(int index, ComponentType type)
     {
         var array = GetArray(type);
         return array.GetValue(index);

--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -5,7 +5,6 @@ using Arch.Core.Utils;
 
 namespace Arch.Core;
 
-
 #if PURE_ECS
 
 /// <summary>
@@ -142,7 +141,7 @@ public readonly struct Entity : IEquatable<Entity>, IComparable<Entity>
     /// <summary>
     ///     A null <see cref="Entity"/> used for comparison.
     /// </summary>
-    public static Entity Null = new(-1, 0);
+    public readonly static Entity Null = new(-1, 0);
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="Entity"/> struct with default values.
@@ -186,7 +185,6 @@ public readonly struct Entity : IEquatable<Entity>, IComparable<Entity>
     {
         return obj is Entity other && Equals(other);
     }
-
 
     /// <summary>
     ///     Compares this <see cref="Entity"/> instace to another one for sorting and ordering.
@@ -328,7 +326,6 @@ public readonly struct EntityReference
         return this == reference;
     }
 #endif
-
 
     /// <summary>
     ///     Checks the <see cref="EntityReference"/> for equality with another one.

--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -182,7 +182,7 @@ public readonly struct Entity : IEquatable<Entity>, IComparable<Entity>
     /// <param name="obj">The other <see cref="Entity"/> object.</param>
     /// <returns>True if equal, false if not.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return obj is Entity other && Equals(other);
     }

--- a/src/Arch/Core/Extensions/Dangerous/DangerousWorldExtensions.cs
+++ b/src/Arch/Core/Extensions/Dangerous/DangerousWorldExtensions.cs
@@ -2,13 +2,13 @@ using Arch.LowLevel.Jagged;
 
 namespace Arch.Core.Extensions.Dangerous;
 
+// NOTE: I am omitting WorldExtensionsAttribute here, as these should be accessed through the original world instead of a wrapper world anyways.
 /// <summary>
 ///     The <see cref="DangerousWorldExtensions"/> class
 ///     contains several <see cref="World"/> related extension methods which give acess to underlaying data structures that should only be modified when you exactly know what you are doing.
 /// </summary>
 public static class DangerousWorldExtensions
 {
-
     /// <summary>
     ///     Sets the <see cref="World.Archetypes"/>.
     /// </summary>
@@ -44,7 +44,6 @@ public static class DangerousWorldExtensions
     {
         world.EntityInfo.Archetypes[entity.Id] = archetype;
     }
-
 
     /// <summary>
     ///     Returns the <see cref="EntityInfoStorage.Versions"/> of a <see cref="World"/> for reading or modifiyng it.

--- a/src/Arch/Core/Extensions/EntityExtensions.cs
+++ b/src/Arch/Core/Extensions/EntityExtensions.cs
@@ -60,12 +60,11 @@ public static partial class EntityExtensions
     /// <returns>A newly allocated array containing the entities components.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static object[] GetAllComponents(this in Entity entity)
+    public static object?[] GetAllComponents(this in Entity entity)
     {
         var world = World.Worlds[entity.WorldId];
         return world.GetAllComponents(entity);
     }
-
 
     /// <summary>
     ///     Checks if the <see cref="Entity"/> is alive in this <see cref="World"/>.
@@ -112,9 +111,9 @@ public static partial class EntityExtensions
     /// </summary>
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="entity">The <see cref="Entity"/>.</param>
-    /// <param name="cmp">The instance, optional.</param>
+    /// <param name="component">The instance, optional.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Set<T>(this in Entity entity, in T component = default)
+    public static void Set<T>(this in Entity entity, in T? component = default)
     {
         var world = World.Worlds[entity.WorldId];
         world.Set(entity, in component);
@@ -158,7 +157,7 @@ public static partial class EntityExtensions
     /// <returns>True if it exists, otherwhise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static bool TryGet<T>(this in Entity entity, out T component)
+    public static bool TryGet<T>(this in Entity entity, out T? component)
     {
         var world = World.Worlds[entity.WorldId];
         return world.TryGet(entity, out component);
@@ -184,26 +183,26 @@ public static partial class EntityExtensions
     /// </summary>
     /// <typeparam name="T">The component type.</typeparam>
     /// <param name="entity">The <see cref="Entity"/>.</param>
-    /// <param name="cmp">The component value used if its being added.</param>
+    /// <param name="component">The component value used if its being added.</param>
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T AddOrGet<T>(this in Entity entity, T cmp = default)
+    public static ref T AddOrGet<T>(this in Entity entity, T? component = default)
     {
         var world = World.Worlds[entity.WorldId];
-        return ref world.AddOrGet(entity, cmp);
+        return ref world.AddOrGet(entity, component);
     }
 
     /// <summary>
     ///     Adds an new component to the <see cref="Entity"/> and moves it to the new <see cref="Archetype"/>.
     /// </summary>
     /// <param name="entity">The <see cref="Entity"/>.</param>
-    /// <param name="cmp">The component instance, optional.</param>
+    /// <param name="component">The component instance, optional.</param>
     /// <typeparam name="T">The component type.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Add<T>(this in Entity entity, in T cmp = default)
+    public static void Add<T>(this in Entity entity, in T? component = default)
     {
         var world = World.Worlds[entity.WorldId];
-        world.Add(entity, cmp);
+        world.Add(entity, component);
     }
 
     /// <summary>
@@ -219,7 +218,6 @@ public static partial class EntityExtensions
     }
 #endif
 }
-
 
 public static partial class EntityExtensions
 {
@@ -332,7 +330,7 @@ public static partial class EntityExtensions
     /// <returns>True if it exists, otherwhise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static bool TryGet(this in Entity entity, ComponentType type, out object component)
+    public static bool TryGet(this in Entity entity, ComponentType type, out object? component)
     {
         var world = World.Worlds[entity.WorldId];
         return world.TryGet(entity, type, out component);
@@ -376,7 +374,6 @@ public static partial class EntityExtensions
         var world = World.Worlds[entity.WorldId];
         world.AddRange(entity, components);
     }
-
 
     /// <summary>
     ///     Removes a list of <see cref="ComponentType"/>'s from the <see cref="Entity"/> and moves it to a different <see cref="Archetype"/>.

--- a/src/Arch/Core/Extensions/EntityExtensions.cs
+++ b/src/Arch/Core/Extensions/EntityExtensions.cs
@@ -284,7 +284,7 @@ public static partial class EntityExtensions
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static object Get(this in Entity entity, ComponentType type)
+    public static object? Get(this in Entity entity, ComponentType type)
     {
         var world = World.Worlds[entity.WorldId];
         return world.Get(entity, type);
@@ -298,7 +298,7 @@ public static partial class EntityExtensions
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static object[] GetRange(this in Entity entity, params ComponentType[] types)
+    public static object?[] GetRange(this in Entity entity, params ComponentType[] types)
     {
         var world = World.Worlds[entity.WorldId];
         return world.GetRange(entity, types);

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -1,5 +1,3 @@
-using System.Buffers;
-using Arch.Core;
 using Arch.Core.Extensions.Internal;
 using Arch.Core.Utils;
 
@@ -9,12 +7,17 @@ namespace Arch.Core.Extensions;
 ///     The <see cref="WorldExtensions"/> class
 ///     adds several usefull utility methods to the <see cref="World"/>.
 /// </summary>
+[WorldExtensions]
 public static class WorldExtensions
 {
 
     /// <summary>
     ///     Reserves space for a certain number of <see cref="Entity"/>'s of a given component structure/<see cref="Archetype"/>.
     /// </summary>
+    /// <remarks>
+    ///     Causes a structural change.
+    /// </remarks>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="types">The component structure/<see cref="Archetype"/>.</param>
     /// <param name="amount">The amount.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -26,6 +29,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Search all matching <see cref="Entity"/>'s and put them into the given <see cref="IList{T}"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which components or <see cref="Entity"/>'s are searched for.</param>
     /// <param name="list">The <see cref="IList{T}"/> receiving the found <see cref="Entity"/>'s.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -35,7 +39,7 @@ public static class WorldExtensions
         foreach (ref var chunk in query)
         {
             ref var entityFirstElement = ref chunk.Entity(0);
-            foreach(var entityIndex in chunk)
+            foreach (var entityIndex in chunk)
             {
                 var entity = Unsafe.Add(ref entityFirstElement, entityIndex);
                 list.Add(entity);
@@ -46,6 +50,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Search all matching <see cref="Archetype"/>'s and put them into the given <see cref="IList{T}"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which components are searched for.</param>
     /// <param name="archetypes">The <see cref="IList{T}"/> receiving <see cref="Archetype"/>'s containing <see cref="Entity"/>'s with the matching components.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -61,6 +66,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Search all matching <see cref="Chunk"/>'s and put them into the given <see cref="IList{T}"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which components are searched for.</param>
     /// <param name="chunks">The <see cref="IList{T}"/> receiving <see cref="Chunk"/>'s containing <see cref="Entity"/>'s with the matching components.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -76,6 +82,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Sets or replaces a <see cref="IList{T}"/> of components for an <see cref="Entity"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="components">The components <see cref="IList{T}"/>.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -87,6 +94,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Checks if an <see cref="Entity"/> has a certain component.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="types">The component <see cref="ComponentType"/>.</param>
     /// <returns>True if it has the desired component, otherwhise false.</returns>
@@ -99,6 +107,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Returns an array of components of an <see cref="Entity"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="types">The component <see cref="ComponentType"/>.</param>
     /// <returns>A reference to the component.</returns>
@@ -111,6 +120,7 @@ public static class WorldExtensions
     /// <summary>
     ///     Returns an array of components of an <see cref="Entity"/>.
     /// </summary>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="types">The component <see cref="ComponentType"/>.</param>
     /// <param name="components">A <see cref="IList{T}"/> where the components are put it.</param>
@@ -129,6 +139,10 @@ public static class WorldExtensions
     /// <summary>
     ///     Adds a <see cref="IList{T}"/> of new components to the <see cref="Entity"/> and moves it to the new <see cref="Archetype"/>.
     /// </summary>
+    /// <remarks>
+    ///     Causes a structural change.
+    /// </remarks>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="components">The component <see cref="IList{T}"/>.</param>
     [SkipLocalsInit]
@@ -141,10 +155,15 @@ public static class WorldExtensions
     /// <summary>
     ///     Adds an list of new components to the <see cref="Entity"/> and moves it to the new <see cref="Archetype"/>.
     /// </summary>
+    /// <remarks>
+    ///     Causes a structural change.
+    /// </remarks>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="components">A <see cref="IList{T}"/> of <see cref="ComponentType"/>'s, those are added to the <see cref="Entity"/>.</param>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [StructuralChange]
     public static void AddRange(this World world, Entity entity, IList<ComponentType> components)
     {
         var oldArchetype = world.EntityInfo.GetArchetype(entity.Id);
@@ -177,9 +196,13 @@ public static class WorldExtensions
 #endif
     }
 
-        /// <summary>
+    /// <summary>
     ///     Removes a list of <see cref="ComponentType"/>'s from the <see cref="Entity"/> and moves it to a different <see cref="Archetype"/>.
     /// </summary>
+    /// <remarks>
+    ///     Causes a structural change.
+    /// </remarks>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="types">A <see cref="IList{T}"/> of <see cref="ComponentType"/>'s, those are removed from the <see cref="Entity"/>.</param>
     [SkipLocalsInit]
@@ -192,10 +215,15 @@ public static class WorldExtensions
     /// <summary>
     ///     Removes a list of <see cref="ComponentType"/>'s from the <see cref="Entity"/> and moves it to a different <see cref="Archetype"/>.
     /// </summary>
+    /// <remarks>
+    ///     Causes a structural change.
+    /// </remarks>
+    /// <param name="world">The <see cref="World"/>.</param>
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="types">A <see cref="IList{T}"/> of <see cref="ComponentType"/>'s, those are removed from the <see cref="Entity"/>.</param>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [StructuralChange]
     public static void RemoveRange(this World world, Entity entity, IList<ComponentType> types)
     {
         var oldArchetype = world.EntityInfo.GetArchetype(entity.Id);

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -5,7 +5,7 @@ namespace Arch.Core.Extensions;
 
 /// <summary>
 ///     The <see cref="WorldExtensions"/> class
-///     adds several usefull utility methods to the <see cref="World"/>.
+///     adds several useful utility methods to the <see cref="World"/>.
 /// </summary>
 [WorldExtensions]
 public static class WorldExtensions

--- a/src/Arch/Core/Jobs/Jobs.cs
+++ b/src/Arch/Core/Jobs/Jobs.cs
@@ -11,16 +11,16 @@ namespace Arch.Core;
 public class DefaultObjectPolicy<T> : IPooledObjectPolicy<T> where T : class, new()
 {
     /// <summary>
-    ///     Creates an instance of the generic type <see cref="T"/>.
+    ///     Creates an instance of the generic type <typeparamref name="T"/>.
     /// </summary>
-    /// <returns>A new instance of <see cref="T"/>.</returns>
+    /// <returns>A new instance of <typeparamref name="T"/>.</returns>
     public T Create()
     {
         return new();
     }
 
     /// <summary>
-    ///     Returns an instance of <see cref="T"/>;
+    ///     Returns an instance of <typeparamref name="T"/>.
     /// </summary>
     /// <param name="obj">The instance.</param>
     /// <returns>True if it was returned sucessfully.</returns>
@@ -85,7 +85,7 @@ public struct ForEachJob : IChunkJob
     /// <param name="index">The chunk index.</param>
     /// <param name="chunk">A reference to the chunk which is currently processed.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Execute(int index, ref Chunk chunk)
+    public readonly void Execute(int index, ref Chunk chunk)
     {
         ref var entityFirstElement = ref chunk.Entity(0);
         foreach(var entityIndex in chunk)
@@ -162,9 +162,9 @@ public class ChunkIterationJob<T> : IJob where T : IChunkJob
     public Chunk[] Chunks { get; set; }
 
     /// <summary>
-    /// An instance of the generic type <see cref="T"/>, being invoked upon each chunk.
+    /// An instance of the generic type <typeparamref name="T"/>, being invoked upon each chunk.
     /// </summary>
-    public T Instance { get; set; }
+    public T? Instance { get; set; }
 
     /// <summary>
     /// From the start how many chunks are processed.
@@ -186,7 +186,7 @@ public class ChunkIterationJob<T> : IJob where T : IChunkJob
         for (var chunkIndex = 0; chunkIndex < Size; chunkIndex++)
         {
             ref var currentChunk = ref Unsafe.Add(ref chunk, chunkIndex);
-            Instance.Execute(Start + chunkIndex, ref currentChunk);
+            Instance?.Execute(Start + chunkIndex, ref currentChunk);
         }
     }
 }

--- a/src/Arch/Core/Jobs/World.Jobs.cs
+++ b/src/Arch/Core/Jobs/World.Jobs.cs
@@ -24,6 +24,9 @@ public partial class World
     ///     Searches all matching <see cref="Entity"/>'s by a <see cref="QueryDescription"/> and calls the passed <see cref="ForEach"/> delegate.
     ///     Runs multithreaded and will process the matching <see cref="Entity"/>'s in parallel.
     /// </summary>
+    /// <remarks>
+    ///     NOT thread-safe! Do not call a parallel query from anything but the main thread!
+    /// </remarks>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which <see cref="Entity"/>'s are searched for.</param>
     /// <param name="forEntity">The <see cref="ForEach"/> delegate.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -41,6 +44,9 @@ public partial class World
     ///     Searches all matching <see cref="Entity"/>'s by a <see cref="QueryDescription"/> and calls the <see cref="IForEach"/> struct.
     ///     Runs multithreaded and will process the matching <see cref="Entity"/>'s in parallel.
     /// </summary>
+    /// <remarks>
+    ///     NOT thread-safe! Do not call a parallel query from anything but the main thread!
+    /// </remarks>
     /// <typeparam name="T">A struct implementation of the <see cref="IForEach"/> interface which is called on each <see cref="Entity"/> found.</typeparam>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which <see cref="Entity"/>'s are searched for.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -54,6 +60,9 @@ public partial class World
     ///     Searches all matching <see cref="Entity"/>'s by a <see cref="QueryDescription"/> and calls the passed <see cref="IForEach"/> struct.
     ///     Runs multithreaded and will process the matching <see cref="Entity"/>'s in parallel.
     /// </summary>
+    /// <remarks>
+    ///     NOT thread-safe! Do not call a parallel query from anything but the main thread!
+    /// </remarks>
     /// <typeparam name="T">A struct implementation of the <see cref="IForEach"/> interface which is called on each <see cref="Entity"/> found.</typeparam>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which <see cref="Entity"/>'s are searched for.</param>
     /// <param name="iForEach">The struct instance of the generic type being invoked.</param>
@@ -66,6 +75,9 @@ public partial class World
     /// <summary>
     ///     Finds all matching <see cref="Chunk"/>'s by a <see cref="QueryDescription"/> and calls an <see cref="IChunkJob"/> on them.
     /// </summary>
+    /// <remarks>
+    ///     NOT thread-safe! Do not call a parallel query from anything but the main thread!
+    /// </remarks>
     /// <typeparam name="T">A struct implementation of the <see cref="IChunkJob"/> interface which is called on each <see cref="Chunk"/> found.</typeparam>
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which <see cref="Chunk"/>'s are searched for.</param>
     /// <param name="innerJob">The struct instance of the generic type being invoked.</param>

--- a/src/Arch/Core/StructuralChangeAttribute.cs
+++ b/src/Arch/Core/StructuralChangeAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace Arch.Core;
+
+/// <summary>
+///     Marks a particular public method on a <see cref="World"/> as causing a structural change.
+///     Structural changes must never be invoked as another thread is accessing the <see cref="World"/> in any way.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class StructuralChangeAttribute : Attribute
+{
+}

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -512,7 +512,9 @@ public static class JobMeta<T> where T : class, new()
 // TODO: Based on the hash of each `Group` we can easily Map a `Group<T, T, T, ...>` to another `Group`.
 //       E.g.: `Group<int, byte>` to `Group<byte, int>`, as they return the same hash.
 /// <summary>
-///     The <see cref="Group"/> class counts the Ids of registered groups in an compiletime static way.
+///     The <see cref="Group"/> class counts the IDs of registered <see cref="ComponentType"/> groups in an compile-time static way,
+///     and stores an underlying array for dynamic access. In this way, its related classes (<see cref="Group{T0}"/>, <see cref="Group{T0, T1}"/>...)
+///     can be used to statically track sets of components from generic calls with zero overhead.
 /// </summary>
 public static class Group
 {

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -70,9 +70,13 @@ public readonly record struct ComponentType
 ///     The <see cref="ComponentRegistry"/> class, tracks all used components in the project.
 ///     Those are represented by <see cref="ComponentType"/>'s.
 /// </summary>
+/// <remarks>
+///     Simultaneous readers are supported, but simultaneous readers and writers are not.
+///     Ensure that modification happens on an isolated thread.
+///     In <see cref="World"/> this is implemented via marked structural-change methods.
+/// </remarks>
 public static class ComponentRegistry
 {
-
     /// <summary>
     ///     All registered components, maps their <see cref="Type"/> to their <see cref="ComponentType"/>.
     /// </summary>
@@ -406,6 +410,9 @@ public static class Component
     /// <summary>
     ///     Searches a <see cref="ComponentType"/> by its <see cref="Type"/>. If it does not exist, it will be added.
     /// </summary>
+    /// <remarks>
+    ///     Not thread-safe; ensure no other threads are accessing or modifying the <see cref="ComponentRegistry"/>.
+    /// </remarks>
     /// <param name="type">The <see cref="Type"/>.</param>
     /// <returns>The <see cref="ComponentType"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -824,7 +824,7 @@ public partial class World
     /// <param name="queryDescription">The <see cref="QueryDescription"/> which specifies which <see cref="Entity"/>s will be targeted.</param>
     /// <param name="value">The value of the component to set.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Set<T>(in QueryDescription queryDescription, in T value = default)
+    public void Set<T>(in QueryDescription queryDescription, in T? value = default)
     {
         var query = Query(in queryDescription);
         foreach (ref var chunk in query)
@@ -854,7 +854,7 @@ public partial class World
     [SkipLocalsInit]
     [StructuralChange]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Add<T>(in QueryDescription queryDescription, in T component = default)
+    public void Add<T>(in QueryDescription queryDescription, in T? component = default)
     {
         // BitSet to stack/span bitset, size big enough to contain ALL registered components.
         Span<uint> stack = stackalloc uint[BitSet.RequiredLength(ComponentRegistry.Size)];
@@ -959,12 +959,12 @@ public partial class World
     /// <param name="entity">The <see cref="Entity"/>.</param>
     /// <param name="component">The instance, optional.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Set<T>(Entity entity, in T component = default)
+    public void Set<T>(Entity entity, in T? component = default)
     {
         var slot = EntityInfo.GetSlot(entity.Id);
         var archetype = EntityInfo.GetArchetype(entity.Id);
         archetype.Set(ref slot, in component);
-        OnComponentSet(entity, component);
+        OnComponentSet<T>(entity);
     }
 
     /// <summary>
@@ -1006,7 +1006,7 @@ public partial class World
     /// <returns>True if it exists, otherwise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public bool TryGet<T>(Entity entity, out T component)
+    public bool TryGet<T>(Entity entity, out T? component)
     {
         component = default;
 
@@ -1056,9 +1056,9 @@ public partial class World
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [StructuralChange]
-    public ref T AddOrGet<T>(Entity entity, T component = default)
+    public ref T AddOrGet<T>(Entity entity, T? component = default)
     {
-        ref var cmp = ref TryGetRef<T>(entity, out var exists);
+        ref T cmp = ref TryGetRef<T>(entity, out var exists);
         if (exists)
         {
             return ref cmp;
@@ -1283,7 +1283,7 @@ public partial class World
     /// <returns>True if it exists, otherwise false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public bool TryGet(Entity entity, ComponentType type, out object component)
+    public bool TryGet(Entity entity, ComponentType type, out object? component)
     {
         component = default;
         if (!Has(entity, type))
@@ -1532,7 +1532,7 @@ public partial class World
     /// <returns>A newly allocated array containing the entities components.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public object[] GetAllComponents(Entity entity)
+    public object?[] GetAllComponents(Entity entity)
     {
         // Get archetype and chunk.
         var entitySlot = EntityInfo.GetEntitySlot(entity.Id);
@@ -1542,7 +1542,7 @@ public partial class World
 
         // Loop over components, collect and returns them.
         var entityIndex = entitySlot.Slot.Index;
-        var cmps = new object[components.Length];
+        var cmps = new object?[components.Length];
 
         for (var index = 0; index < components.Length; index++)
         {

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1229,7 +1229,7 @@ public partial class World
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public object Get(Entity entity, ComponentType type)
+    public object? Get(Entity entity, ComponentType type)
     {
         var entitySlot = EntityInfo.GetEntitySlot(entity.Id);
         return entitySlot.Archetype.Get(ref entitySlot.Slot, type);
@@ -1243,10 +1243,10 @@ public partial class World
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public object[] GetRange(Entity entity, Span<ComponentType> types)
+    public object?[] GetRange(Entity entity, Span<ComponentType> types)
     {
         var entitySlot = EntityInfo.GetEntitySlot(entity.Id);
-        var array = new object[types.Length];
+        var array = new object?[types.Length];
         for (var index = 0; index < types.Length; index++)
         {
             var type = types[index];
@@ -1263,7 +1263,7 @@ public partial class World
     /// <param name="types">The component <see cref="ComponentType"/>.</param>
     /// <param name="components">A <see cref="Span{T}"/> in which the components are put.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void GetRange(Entity entity, Span<ComponentType> types, Span<object> components)
+    public void GetRange(Entity entity, Span<ComponentType> types, Span<object?> components)
     {
         var entitySlot = EntityInfo.GetEntitySlot(entity.Id);
         for (var index = 0; index < types.Length; index++)

--- a/src/Arch/Core/WorldExtensionsAttribute.cs
+++ b/src/Arch/Core/WorldExtensionsAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace Arch.Core;
+
+// NOTE: we should consider making this internal, if it's possible to expose internals to Arch.Extended
+/// <summary>
+/// Tags a class as containing extensions for <see cref="World"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class WorldExtensionsAttribute : Attribute
+{
+}

--- a/src/Arch/Core/WorldExtensionsAttribute.cs
+++ b/src/Arch/Core/WorldExtensionsAttribute.cs
@@ -1,6 +1,5 @@
 ﻿namespace Arch.Core;
 
-// NOTE: we should consider making this internal, if it's possible to expose internals to Arch.Extended
 /// <summary>
 /// Tags a class as containing extensions for <see cref="World"/>.
 /// </summary>


### PR DESCRIPTION
* Fixes some concurrency issues with `World` to make it thread-safe (outside of structural change and parallel query methods)
    + Of note, adds necessary locking mechanisms to World.Events.cs and `world.Query()` (the query caching behaviour)
* Annotates structural changes with `[StructuralChange]` in World.cs
* Annotates safe world extension methods with `[WorldExtension]`
* Changes World API to officially support null class components through nullables, and fixes many (not all) nullable issues in the project
* Makes `Group<T0, ...>.Hash` and `.Types` public
* Minor improvements to documentation and code style based on the current .editorconfig, mostly focusing on World.cs
* Compiler and intellisense warning fixes