### PR TITLE
Fixed Some Array Extensions Bugs

### DIFF
--- a/src/Arch.Tests/Arch.Tests.csproj
+++ b/src/Arch.Tests/Arch.Tests.csproj
@@ -59,4 +59,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
+++ b/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
@@ -6,28 +6,6 @@ namespace Arch.Core.Extensions.Internal;
 /// </summary>
 internal static class ArrayExtensions
 {
-
-    /// <summary>
-    ///     Adds an item to an array at a given index. Resizes the array if necessary.
-    /// </summary>
-    /// <param name="target">The target array.</param>
-    /// <param name="index">The index.</param>
-    /// <param name="item">The item.</param>
-    /// <typeparam name="T">The type.</typeparam>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void Add<T>(this T[] target, int index, T item)
-    {
-        if (target.Length <= index)
-        {
-            var doublingCount = (int)Math.Ceiling(Math.Log(index / (double)target.Length, 2));
-            var result = target.Length * (int)Math.Pow(2, doublingCount);
-
-            Array.Resize(ref target, result);
-        }
-
-        target[index] = item;
-    }
-
     /// <summary>
     ///     Adds a list of items to an array.
     /// </summary>
@@ -114,44 +92,11 @@ internal static class ArrayExtensions
     }
 
     /// <summary>
-    ///     Gets the element at an index in the array, or resizes it to fit an element
-    ///     at that index.
-    /// </summary>
-    /// <param name="array">The array to get the element from.</param>
-    /// <param name="index">The index of the element.</param>
-    /// <param name="exists">
-    ///     Whether or not the index was within the bounds of the array.
-    ///     When false, the array has been resized.
-    /// </param>
-    /// <param name="maxSize">The max size to grow the array to.</param>
-    /// <typeparam name="T">The element type of the array.</typeparam>
-    /// <returns>The element at that index. May be null.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static ref T GetOrResize<T>(ref T[] array, int index, int? maxSize = null)
-    {
-        if (index < array.Length)
-        {
-            return ref array[index];
-        }
-
-        if (maxSize == null)
-        {
-            Array.Resize(ref array, (index * 2) + 1);
-        }
-        else
-        {
-            Array.Resize(ref array, Math.Min((index * 2) + 1, maxSize.Value));
-        }
-
-        return ref array[index];
-    }
-
-    /// <summary>
     ///     Removes a list of items from an array by value equality.
     /// </summary>
     /// <typeparam name="T">The generic type.</typeparam>
-    /// <param name="target">The target array.</param>
-    /// <param name="items">The <see cref="IList"/> of items which will be removed.</param>
+    /// <param name="array">The target array.</param>
+    /// <param name="toRemove">The <see cref="IList"/> of items which will be removed.</param>
     /// <returns>The new array.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static T[] Remove<T>(this T[] array, IList<T> toRemove)

--- a/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
+++ b/src/Arch/Core/Extensions/Internal/ArrayExtensions.cs
@@ -7,6 +7,34 @@ namespace Arch.Core.Extensions.Internal;
 internal static class ArrayExtensions
 {
     /// <summary>
+    ///     Adds an item to an array at a given index. Resizes the array if necessary.
+    /// </summary>
+    /// <param name="target">The target array.</param>
+    /// <param name="index">The index.</param>
+    /// <param name="item">The item.</param>
+    /// <typeparam name="T">The type.</typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static T[] Add<T>(this T[] target, int index, T item)
+    {
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        if (target.Length <= index)
+        {
+            var doublingCount = Math.Max(1, (int)Math.Ceiling(Math.Log(index / (double)target.Length, 2)));
+            var result = target.Length * (int)Math.Pow(2, doublingCount);
+
+            Array.Resize(ref target, result);
+        }
+
+        target[index] = item;
+
+        return target;
+    }
+
+    /// <summary>
     ///     Adds a list of items to an array.
     /// </summary>
     /// <typeparam name="T">The generic type.</typeparam>


### PR DESCRIPTION
I started testing the `ArrayExtension` methods and discovered a bug in the `Add` and `GetOrResize` methods. Both methods internally call `Array.Resize`, but they never return the new array! This is probably because the method is very badly named and implies that it will somehow resize an existing array, this is not the case. To quote the docs:

> This method allocates a new array with the specified size, copies elements from the old array to the new one, and then replaces the old array with the new one.

---

The `GetOrResize` method was not used anywhere, so I simply deleted it.

The `Add` method was only used in the `CompileTimeStatics` class, which was using a `Type[]` as a map from `int -> Type`. Replaced this with an actual `Dictionary<int, Type>` instead, removing the need for the extension.