### PR TITLE
CommandBuffer Tests And Fixes

### DIFF
--- a/src/Arch.Tests/Extensions/ArrayExtensionsTests.cs
+++ b/src/Arch.Tests/Extensions/ArrayExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿using Arch.Core.Extensions.Internal;
+
+namespace Arch.Tests.Extensions;
+
+[TestFixture]
+public class ArrayExtensionsTests
+{
+    [Test]
+    public void Add_InRange()
+    {
+        var arr = new[] { 1, 2, 3 };
+        arr.Add(0, 7);
+
+        CollectionAssert.AreEqual(new[] { 7, 2, 3 }, arr);
+    }
+
+    [Test]
+    public void Add_OutOfRange()
+    {
+        var arr = new[] { 1, 2, 3 };
+        arr = arr.Add(3, 7);
+
+        // The array might be any size now.
+        // All we need to check if that the first 4 elements are correct.
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 7 }, arr.Take(4));
+    }
+
+    [Test]
+    public void Add_FarOutOfRange()
+    {
+        var arr = new[] { 1, 2, 3 };
+        arr = arr.Add(30, 7);
+
+        // The array might be any size now.
+        // All we need to check if that the first 3 elements are correct and the 30th is 7.
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, arr.Take(3));
+        Assert.That(arr[30], Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Add_VeryFarOutOfRange()
+    {
+        var arr = new[] { 1, 2, 3 };
+        arr = arr.Add(3000, 7);
+
+        // The array might be any size now.
+        // All we need to check if that the first 3 elements are correct and the 30th is 7.
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, arr.Take(3));
+        Assert.That(arr[3000], Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Add_NegativeIndex()
+    {
+        var arr = new[] { 1, 2, 3 };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => arr.Add(-1, 7));
+    }
+}

--- a/src/Arch/CommandBuffer/CommandBuffer.cs
+++ b/src/Arch/CommandBuffer/CommandBuffer.cs
@@ -177,7 +177,7 @@ public class CommandBuffer : IDisposable
     {
         lock (this)
         {
-            var entity = new Entity(-Math.Abs(Size + 1), World.Id);
+            var entity = new Entity(-(Size + 1), World.Id);
             Register(entity, out _);
 
             var command = new CreateCommand(Size - 1, types);

--- a/src/Arch/CommandBuffer/CommandBuffer.cs
+++ b/src/Arch/CommandBuffer/CommandBuffer.cs
@@ -177,7 +177,7 @@ public class CommandBuffer : IDisposable
     {
         lock (this)
         {
-            var entity = new Entity(-Math.Abs(Size - 1), World.Id);
+            var entity = new Entity(-Math.Abs(Size + 1), World.Id);
             Register(entity, out _);
 
             var command = new CreateCommand(Size - 1, types);
@@ -433,15 +433,15 @@ public class CommandBuffer : IDisposable
 
         // Reset values.
         Size = 0;
-        Entities?.Clear();
-        BufferedEntityInfo?.Clear();
-        Creates?.Clear();
-        Sets?.Clear();
-        Adds?.Clear();
-        Removes?.Clear();
-        Destroys?.Clear();
-        _addTypes?.Clear();
-        _removeTypes?.Clear();
+        Entities.Clear();
+        BufferedEntityInfo.Clear();
+        Creates.Clear();
+        Sets.Clear();
+        Adds.Clear();
+        Removes.Clear();
+        Destroys.Clear();
+        _addTypes.Clear();
+        _removeTypes.Clear();
     }
 
     /// <summary>
@@ -449,15 +449,15 @@ public class CommandBuffer : IDisposable
     /// </summary>
     public void Dispose()
     {
-        Entities?.Dispose();
-        BufferedEntityInfo?.Dispose();
-        Creates?.Clear();
-        Sets?.Clear();
-        Adds?.Clear();
-        Removes?.Clear();
-        Destroys?.Dispose();
-        _addTypes?.Dispose();
-        _removeTypes?.Dispose();
+        Entities.Dispose();
+        BufferedEntityInfo.Dispose();
+        Creates.Clear();
+        Sets.Clear();
+        Adds.Clear();
+        Removes.Clear();
+        Destroys.Dispose();
+        _addTypes.Dispose();
+        _removeTypes.Dispose();
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
 - Added some more tests covering the `CommandBuffer`. Fixed a bug in `Create` method, sometimes assigning duplicate IDs.
 - Removed all conditional access in `Playback` and `Dispose`, those things are never null.
 - Added ArrayExtensions tests (these were meant to be in the PR yesterday, oops).

### Duplicate IDs

The previous system to assign IDs in the CommandBuffer was `-Math.Abs(Size - 1)`, which produces a sequence like this:
 - 0 => -1
 - 1 => 0
 - 2 => -1
 - 3 => -2

The duplicate for items 0 and 2 was causing a problem.

New sequence is `-(Size + 1)`:
 - 0 => -1
 - 1 => -2
 - 2 => -3
 - 3 => -4