### PR TITLE
Enumerator Tests

### DIFF
--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -404,7 +404,7 @@ public sealed partial class Archetype
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Enumerator<Chunk> GetEnumerator()
     {
-        return new Enumerator<Chunk>(Chunks.AsSpan(), Size);
+        return new Enumerator<Chunk>(Chunks.AsSpan(0, Size));
     }
 
     /// <summary>

--- a/src/Arch/Core/Enumerators.cs
+++ b/src/Arch/Core/Enumerators.cs
@@ -40,22 +40,6 @@ public ref struct Enumerator<T>
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="Enumerator{T}"/> struct.
-    /// </summary>
-    /// <param name="span">The <see cref="Span{T}"/> with items to iterate over.</param>
-    /// <param name="length">Its length or size.</param>
-    public Enumerator(Span<T> span, int length)
-    {
-#if NET7_0_OR_GREATER
-        _ptr = ref MemoryMarshal.GetReference(span);
-#else
-        _ptr = new Ref<T>(ref span.DangerousGetReference());
-#endif
-        _length = length;
-        _index = _length;
-    }
-
-    /// <summary>
     ///     Moves to the next item.
     /// </summary>
     /// <returns>True if there still items, otherwhise false.</returns>


### PR DESCRIPTION
Added tests covering `Enumerator`. 

The `(Span<T> span, int length)` constructor makes it very easy to access out of bounds. Initially I added range checking, but I think it's neater to just remove that constructor altogether. The call site (there is only one) can slice the `Span` to the correct length.