### PR TITLE
Fix leftover nullability warnings

### DIFF
--- a/src/Arch/Core/EntityInfo.cs
+++ b/src/Arch/Core/EntityInfo.cs
@@ -109,7 +109,7 @@ internal class EntityInfoStorage
         );
         EntitySlots = new JaggedArray<EntitySlot>(
             cpuL1CacheSize / Unsafe.SizeOf<EntitySlot>(),
-            new EntitySlot(null, new Slot(-1,-1)),
+            new EntitySlot(null!, new Slot(-1,-1)),
             256
         );
     }

--- a/src/Arch/Core/Extensions/EntityExtensions.cs
+++ b/src/Arch/Core/Extensions/EntityExtensions.cs
@@ -314,7 +314,7 @@ public static partial class EntityExtensions
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [Pure]
-    public static void GetRange(this in Entity entity, ComponentType[] types, IList<object> components)
+    public static void GetRange(this in Entity entity, ComponentType[] types, IList<object?> components)
     {
         var world = World.Worlds[entity.WorldId];
         world.GetRange(entity, types, components);

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -112,7 +112,7 @@ public static class WorldExtensions
     /// <param name="types">The component <see cref="ComponentType"/>.</param>
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static object[] GetRange(this World world, Entity entity, params ComponentType[] types)
+    public static object?[] GetRange(this World world, Entity entity, params ComponentType[] types)
     {
         return world.GetRange(entity, types);
     }

--- a/src/Arch/Core/Extensions/WorldExtensions.cs
+++ b/src/Arch/Core/Extensions/WorldExtensions.cs
@@ -126,7 +126,7 @@ public static class WorldExtensions
     /// <param name="components">A <see cref="IList{T}"/> where the components are put it.</param>
     /// <returns>A reference to the component.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void GetRange(this World world, Entity entity, ComponentType[] types, IList<object> components)
+    public static void GetRange(this World world, Entity entity, ComponentType[] types, IList<object?> components)
     {
         var entitySlot = world.EntityInfo.GetEntitySlot(entity.Id);
         for (var index = 0; index < types.Length; index++)

--- a/src/Arch/Core/Utils/CompileTimeStatics.cs
+++ b/src/Arch/Core/Utils/CompileTimeStatics.cs
@@ -41,7 +41,7 @@ public readonly record struct ComponentType
     public Type Type
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => ComponentRegistry.Types[Id];
+        get => ComponentRegistry.Types[Id]!;
     }
 
     /// <summary>

--- a/src/Arch/Core/Utils/EntityDebugView.cs
+++ b/src/Arch/Core/Utils/EntityDebugView.cs
@@ -43,17 +43,17 @@ internal sealed class EntityDebugView
     /// <summary>
     ///     The <see cref="Entity"/>s components.
     /// </summary>
-    public object[] Components { get; }
+    public object[]? Components { get; }
 
     /// <summary>
     ///     The <see cref="World"/> this <see cref="Entity"/> lives in.
     /// </summary>
-    public World World => IsAlive ? World.Worlds[_entity.WorldId] : null;
+    public World? World => IsAlive ? World.Worlds[_entity.WorldId] : null;
 
     /// <summary>
     ///     The <see cref="Archetype"/> this <see cref="Entity"/> lives in.
     /// </summary>
-    public Archetype Archetype => IsAlive ? World.Worlds[_entity.WorldId].GetArchetype(_entity) : null;
+    public Archetype? Archetype => IsAlive ? World.Worlds[_entity.WorldId].GetArchetype(_entity) : null;
 
     /// <summary>
     ///     The <see cref="Archetype"/> this <see cref="Entity"/> lives in.
@@ -63,7 +63,7 @@ internal sealed class EntityDebugView
     /// <summary>
     ///     The stored <see cref="EntityInfo"/> for this <see cref="Entity"/>.
     /// </summary>
-    public EntityInfo EntityInfo => IsAlive ? World.EntityInfo[_entity.Id] : new EntityInfo();
+    public EntityInfo EntityInfo => IsAlive ? World?.EntityInfo[_entity.Id] ?? new EntityInfo() : new EntityInfo();
 }
 
 #endif


### PR DESCRIPTION
The one in CompileTimeStatics is suppressed since that only happens if you explicitly remove the type yourself.
The one in EntityInfo is also as it's the filler value.