### PR TITLE
Fix bug in structural sparse array, resulting in massive performance loss due to reallocation. Affecting command buffer heavily.

### DIFF
--- a/src/Arch/CommandBuffer/StructuralSparseSet.cs
+++ b/src/Arch/CommandBuffer/StructuralSparseSet.cs
@@ -203,7 +203,7 @@ internal class StructuralSparseSet
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AddStructuralSparseArray(ComponentType type)
     {
-        Components[type.Id] = new StructuralSparseArray(type, type.Id);
+        Components[type.Id] = new StructuralSparseArray(type, Capacity);
 
         Used[UsedSize] = type.Id;
         UsedSize++;


### PR DESCRIPTION
You wrote type.Id instead of passing along Capacity.