### PR TITLE
Move EntityReference.IsAlive to World

### DIFF
--- a/src/Arch/Core/Entity.cs
+++ b/src/Arch/Core/Entity.cs
@@ -293,24 +293,7 @@ public readonly struct EntityReference
         Version = -1;
     }
 
-#if PURE_ECS
-
-    /// <summary>
-    ///     Checks if the referenced <see cref="Entity"/> is still valid and alife.
-    /// </summary>
-    /// <param name="world">The <see cref="Entity"/> <see cref="World"/>..</param>
-    /// <returns>True if its alive, otherwhise false.</returns>
-    public bool IsAlive(World world)
-    {
-        if (this == Null)
-        {
-            return false;
-        }
-
-        var reference = world.Reference(Entity);
-        return this == reference;
-    }
-#else
+#if !PURE_ECS
     /// <summary>
     ///     Checks if the referenced <see cref="Entity"/> is still valid and alife.
     /// </summary>

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1422,6 +1422,24 @@ public partial class World
 public partial class World
 {
     /// <summary>
+    ///     Checks if the <see cref="EntityReference"/> is alive and valid in this <see cref="World"/>.
+    /// </summary>
+    /// <param name="entityReference">The <see cref="EntityReference"/>.</param>
+    /// <returns>True if it exists and is alive, otherwise false.</returns>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsAlive(EntityReference entityReference)
+    {
+        if (entityReference == EntityReference.Null)
+        {
+            return false;
+        }
+
+        var reference = Reference(entityReference.Entity);
+        return entityReference == reference;
+    }
+
+    /// <summary>
     ///     Checks if the <see cref="Entity"/> is alive in this <see cref="World"/>.
     /// </summary>
     /// <param name="entity">The <see cref="Entity"/>.</param>


### PR DESCRIPTION
Resolves https://github.com/genaray/Arch/issues/187

IMO this is better due to the aforementioned issue as it doesn't really feel like ECS. Not sure if the preference is to Obsolete the old one or just remove it.