### PR TITLE
Add component existence check

### DIFF
--- a/src/Arch.Tests/ChunkTest.cs
+++ b/src/Arch.Tests/ChunkTest.cs
@@ -140,4 +140,21 @@ public sealed class ChunkTest
         That(_chunk.Has<Ai>(), Is.False);
         That(_chunk.Has<Rotation>(), Is.True);
     }
+
+    [Test]
+    public void ChunkErrors()
+    {
+        _chunk = new Chunk(1000, _types);
+
+        Throws<InvalidOperationException>(() => _chunk.GetArray<Ai>());
+        Throws<InvalidOperationException>(() => _chunk.Get<Ai>(0));
+        Throws<InvalidOperationException>(() => _chunk.Set<Ai>(0, default));
+        Throws<InvalidOperationException>(() => _chunk.GetFirst<Ai>());
+
+        var type = (ComponentType)typeof(Ai);
+
+        Throws<InvalidOperationException>(() => _chunk.GetArray(type));
+        Throws<InvalidOperationException>(() => _chunk.Get(0, type));
+        Throws<InvalidOperationException>(() => _chunk.Set(0, (object)default(Ai)));
+    }
 }

--- a/src/Arch.Tests/WorldTest.cs
+++ b/src/Arch.Tests/WorldTest.cs
@@ -188,7 +188,7 @@ public sealed partial class WorldTest
 #endif
 
         // Entity reference null is NOT alive.
-        EntityReference cons = new EntityReference{};
+        EntityReference cons = new EntityReference { };
         EntityReference refs = EntityReference.Null;
 
 #if PURE_ECS
@@ -411,7 +411,7 @@ public partial class WorldTest
     {
 
         var queryDesc = new QueryDescription().WithAll<Transform>();
-        _world.Set(in queryDesc, new Transform{ X = 100, Y = 100});
+        _world.Set(in queryDesc, new Transform { X = 100, Y = 100 });
         _world.Query(in queryDesc, (ref Transform transform) =>
         {
             That(transform.X, Is.EqualTo(100));
@@ -476,7 +476,7 @@ public partial class WorldTest
         for (int index = 0; index < 1000; index++)
         {
             var entity = world.Create(_entityGroup);
-            world.Add(entity,10);
+            world.Add(entity, 10);
         }
 
         // Add int to all entities without int
@@ -486,8 +486,10 @@ public partial class WorldTest
         var counter = 0;
         world.Query(in withIntQueryDesc, (ref int i) =>
         {
-            if (i == 10) previousCounter++;
-            if (i == 100) counter++;
+            if (i == 10)
+                previousCounter++;
+            if (i == 100)
+                counter++;
         });
 
         That(world.CountEntities(in withIntQueryDesc), Is.EqualTo(2000));
@@ -527,7 +529,6 @@ public partial class WorldTest
     [Test]
     public void SetGetAndHas()
     {
-
         var entity = _world.Create(_entityGroup);
         True(_world.Has<Transform>(entity));
 
@@ -536,6 +537,9 @@ public partial class WorldTest
 
         That(transform.X, Is.EqualTo(10));
         That(transform.Y, Is.EqualTo(10));
+
+        Throws<InvalidOperationException>(() => _world.Get<Ai>(entity));
+        Throws<InvalidOperationException>(() => _world.Set<Ai>(entity, default));
     }
 
     /// <summary>
@@ -544,7 +548,6 @@ public partial class WorldTest
     [Test]
     public void Remove()
     {
-
         var entity = _world.Create(_entityGroup);
         var entity2 = _world.Create(_entityGroup);
         _world.Remove<Transform>(entity);
@@ -553,6 +556,8 @@ public partial class WorldTest
         That(_world.GetArchetype(entity2), Is.EqualTo(_world.GetArchetype(entity)));
         That(_world.GetArchetype(entity).ChunkCount, Is.EqualTo(1));
         That(_world.GetArchetype(entity).Chunks[0].Size, Is.EqualTo(2));
+
+        Throws<InvalidOperationException>(() => _world.Remove<Ai>(entity));
     }
 
     /// <summary>
@@ -569,6 +574,8 @@ public partial class WorldTest
         _world.TryGetArchetype(_entityAiGroup, out var arch);
         That(_world.GetArchetype(entity2), Is.EqualTo(_world.GetArchetype(entity)));
         That(arch, Is.EqualTo(_world.GetArchetype(entity)));
+
+        Throws<InvalidOperationException>(() => _world.Add<Ai>(entity));
     }
 }
 
@@ -591,6 +598,9 @@ public partial class WorldTest
 
         That(transform.X, Is.EqualTo(10));
         That(transform.Y, Is.EqualTo(10));
+
+        Throws<InvalidOperationException>(() => _world.Get(entity, typeof(Ai)));
+        Throws<InvalidOperationException>(() => _world.Set(entity, (object)default(Ai)));
     }
 
     /// <summary>
@@ -607,6 +617,8 @@ public partial class WorldTest
         That(_world.GetArchetype(entity2), Is.EqualTo(_world.GetArchetype(entity)));
         That(_world.GetArchetype(entity).ChunkCount, Is.EqualTo(1));
         That(_world.GetArchetype(entity).Chunks[0].Size, Is.EqualTo(2));
+
+        Throws<InvalidOperationException>(() => _world.RemoveRange(entity, typeof(Ai)));
     }
 
     /// <summary>
@@ -623,6 +635,8 @@ public partial class WorldTest
         _world.TryGetArchetype(_entityAiGroup, out var arch);
         That(_world.GetArchetype(entity2), Is.EqualTo(_world.GetArchetype(entity)));
         That(arch, Is.EqualTo(_world.GetArchetype(entity)));
+
+        Throws<InvalidOperationException>(() => _world.AddRange(entity, new Ai()));
     }
 }
 

--- a/src/Arch/Core/Utils/ThrowHelper.cs
+++ b/src/Arch/Core/Utils/ThrowHelper.cs
@@ -7,12 +7,12 @@ internal static class ThrowHelper
     [DoesNotReturn]
     public static void Throw_ComponentDoesNotExists(ComponentType type)
     {
-        throw new ArgumentException($"Component {type.Type} does not exists");
+        throw new InvalidOperationException($"You are trying to access a component({type}) that does not exist in the entity or chunk.");
     }
 
     [DoesNotReturn]
-    public static void Throw_EntityDoesNotExists()
+    public static void Throw_SameArchetype()
     {
-        throw new ArgumentException($"Entity does not exists");
+        throw new InvalidOperationException($"From-Archetype is the same as the To-Archetype. Entities cannot move within the same archetype using this function. Probably an attempt was made to attach already existing components to the entity or to remove non-existing ones.");
     }
 }

--- a/src/Arch/Core/Utils/ThrowHelper.cs
+++ b/src/Arch/Core/Utils/ThrowHelper.cs
@@ -1,0 +1,18 @@
+using Arch.Core.Utils;
+
+namespace Arch;
+
+internal static class ThrowHelper
+{
+    [DoesNotReturn]
+    public static void Throw_ComponentDoesNotExists(ComponentType type)
+    {
+        throw new ArgumentException($"Component {type.Type} does not exists");
+    }
+
+    [DoesNotReturn]
+    public static void Throw_EntityDoesNotExists()
+    {
+        throw new ArgumentException($"Entity does not exists");
+    }
+}

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -325,8 +325,11 @@ public partial class World : IDisposable
     internal void Move(Entity entity, Archetype source, Archetype destination, out Slot destinationSlot)
     {
         // A common mistake, happening in many cases.
-        Debug.Assert(source != destination, "From-Archetype is the same as the To-Archetype. Entities cannot move within the same archetype using this function. Probably an attempt was made to attach already existing components to the entity or to remove non-existing ones.");
-
+        if (source == destination)
+        {
+            ThrowHelper.Throw_SameArchetype();
+        }
+        
         // Copy entity to other archetype
         ref var slot = ref EntityInfo.GetSlot(entity.Id);
         var created = destination.Add(entity, out destinationSlot);


### PR DESCRIPTION
Add checks and exceptions for Add/Remove/Get/Set related to #174. This PR will change it to throw `InvalidOperationException` if you specify a component type that does not exist.

It is recommended to use exceptions instead of assertions here. These are public APIs of the library, and an exception should be thrown if the user specifies an incorrect parameter. When these defects occur during release builds, Arch makes heavy use of unsafe memory operations, which can cause crashes or unexpected behavior, making it difficult to identify the cause. For the above reasons, I changed `Debug.Assert` of `World.Move` to an exception.

The reason why we use a dedicated `ThrowHelper` to throw exceptions is due to optimization. This method is widely used in .NET.