### PR TITLE
opt: avoid memory peak on chunk rent

### DIFF
--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -547,6 +547,11 @@ public sealed unsafe partial class Archetype
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureChunkCapacity(int newCapacity)
     {
+        if (ChunkCapacity >= newCapacity)
+        {
+            return;
+        }
+
         // Increase chunk array size
         var newChunks = ArrayPool<Chunk>.Shared.Rent(newCapacity);
         Array.Copy(Chunks, newChunks, ChunkCapacity);


### PR DESCRIPTION
Check capacity before rent new chunks in archetype