### PR TITLE
Fix thread-safety problem in World.WordSize

### DIFF
--- a/src/Arch.Tests/MultiThreadTest.cs
+++ b/src/Arch.Tests/MultiThreadTest.cs
@@ -1,0 +1,43 @@
+using Arch.Core;
+using static NUnit.Framework.Assert;
+
+namespace Arch.Tests;
+
+[TestFixture]
+public class MultiThreadTest
+{
+    /// <summary>
+    /// Checks if the <see cref="World.WorldSize"/> is correct when creating World multithreaded.
+    /// </summary>
+    [Test]
+    public void MultiThreadedCreateAndDestroy()
+    {
+        int originalWorldSize = World.WorldSize;
+        const int testCount = 10;
+        for (int i = 0; i < testCount; ++i)
+        {
+            var threads = new List<Thread>();
+            for (var j = 0; j < Environment.ProcessorCount; j++)
+            {
+                var thread = new Thread(() =>
+                {
+                    for (var j = 0; j < 1000; j++)
+                    {
+                        var world = World.Create();
+                        World.Destroy(world);
+                    }
+                });
+                threads.Add(thread);
+            }
+
+            threads.ForEach(t => t.Start());
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            That(World.WorldSize, Is.EqualTo(originalWorldSize));
+        }
+    }
+}

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -81,7 +81,9 @@ public partial class World
     /// <summary>
     ///     Tracks how many <see cref="World"/>s exists.
     /// </summary>
-    public static int WorldSize {  get;  private set; }
+    public static int WorldSize => Interlocked.CompareExchange(ref worldSizeUnsafe, 0, 0);
+
+    private static int worldSizeUnsafe;
 
     /// <summary>
     ///     The shared static <see cref="JobScheduler"/> used for Multithreading.
@@ -114,7 +116,7 @@ public partial class World
             }
 
             Worlds[recycledId] = world;
-            WorldSize++;
+            Interlocked.Increment(ref worldSizeUnsafe);
             return world;
         }
 #endif
@@ -131,7 +133,7 @@ public partial class World
         {
             Worlds[world.Id] = null!;
             RecycledWorldIds.Enqueue(world.Id);
-            WorldSize--;
+            Interlocked.Decrement(ref worldSizeUnsafe);
         }
 #endif
 


### PR DESCRIPTION
I found that World.WorldSize can have unintended value when create and destroy World multi-threaded.
Simply use Interlocked methods to solve this problem.

Also unit test added: MultiThreadTest.MultiThreadedCreateAndDestroy

Sometimes test failed before fix.