### PR TITLE
bump actions/upload-artifact version

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -54,7 +54,7 @@ jobs:
       run: ./scripts/Test.sh
 
     - name: Upload dotnet test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dotnet-results
         path: TestResults


### PR DESCRIPTION
GitHub Actions fails any flow that uses actions/upload-artifact@v3.

This pull request includes a small but important change to the `.github/workflows/workflows.yaml` file. The change updates the version of the `actions/upload-artifact` action used in the workflow.

* [`.github/workflows/workflows.yaml`](diffhunk://#diff-91e06c8e996e962256a5c34a92a1506e22be2d32bdc601694c02722a02c4fa34L57-R57): Updated the `actions/upload-artifact` action from version `v3` to `v4`.

