### PR TITLE
Fix EVENTS: Use arch.Signature instead of arch.Types

### DIFF
--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -374,7 +374,7 @@ public partial class World : IDisposable
         #if EVENTS
         // Raise the OnComponentRemoved event for each component on the entity.
         var arch = GetArchetype(entity);
-        foreach (var compType in arch.Types)
+        foreach (var compType in arch.Signature.Components)
         {
             OnComponentRemoved(entity, compType);
         }
@@ -771,7 +771,7 @@ public partial class World
                     #if EVENTS
                     // Raise the OnComponentRemoved event for each component on the entity.
                     var arch = GetArchetype(entity);
-                    foreach (var compType in arch.Types)
+                    foreach (var compType in arch.Signature.Components)
                     {
                         OnComponentRemoved(entity, compType);
                     }

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -374,7 +374,7 @@ public partial class World : IDisposable
         #if EVENTS
         // Raise the OnComponentRemoved event for each component on the entity.
         var arch = GetArchetype(entity);
-        foreach (var compType in arch.Signature.Components)
+        foreach (var compType in arch.Signature)
         {
             OnComponentRemoved(entity, compType);
         }
@@ -771,7 +771,7 @@ public partial class World
                     #if EVENTS
                     // Raise the OnComponentRemoved event for each component on the entity.
                     var arch = GetArchetype(entity);
-                    foreach (var compType in arch.Signature.Components)
+                    foreach (var compType in arch.Signature)
                     {
                         OnComponentRemoved(entity, compType);
                     }


### PR DESCRIPTION
This PR fixes a build error when the EVENTS flag is set, by updating the reference to `arch.Types` to `arch.Signature` as recommended on Discord by clxs.