### PR TITLE
Fix: StructuralSparseSet.Clear

### DIFF
--- a/src/Arch/Buffer/StructuralSparseSet.cs
+++ b/src/Arch/Buffer/StructuralSparseSet.cs
@@ -103,7 +103,7 @@ internal class StructuralSparseArray
     /// </summary>
     public void Clear()
     {
-        Array.Fill(Entities, -1, 0, Size);
+        Array.Fill(Entities, -1);
         Size = 0;
     }
 }


### PR DESCRIPTION
`StructuralSparseArray` was improperly cleared as it used `Size` that refers to the actual number of entities instead of the length of the `Entities` array itself.

In `CommandBuffer`, it was leading to leftovers from the previous iteration if it was re-used after `Playback` resulting in the inconsistent state.