### PR TITLE
Fix StructuralSparseArray Clear function and add basic test

### DIFF
--- a/src/Arch.Tests/StructuralSparseArrayTest.cs
+++ b/src/Arch.Tests/StructuralSparseArrayTest.cs
@@ -1,0 +1,57 @@
+﻿using Arch.Buffer;
+
+namespace Arch.Tests;
+
+[TestFixture]
+public sealed partial class StructuralSparseArrayTest
+{
+    private static void TestEquivalent(StructuralSparseArray test, HashSet<int> control)
+    {
+        // Brute force test every index
+        for (int i = 0; i < 128; i++)
+        {
+            bool contains = control.Contains(i);
+            Assert.That(test.Contains(i), Is.EqualTo(contains));
+        }
+    }
+
+    [Test]
+    public void ClearAndAccessMany()
+    {
+        var test = new StructuralSparseArray(new(1, 0));
+        var control = new HashSet<int>();
+
+        for (int i = 0; i < 10; i++)
+        {
+            control.Add(52 + i);
+            test.Add(52 + i);
+
+            TestEquivalent(test, control);
+
+            control.Add(3 + i);
+            test.Add(3 + i);
+
+            TestEquivalent(test, control);
+
+            control.Clear();
+            test.Clear();
+
+            TestEquivalent(test, control);
+
+            control.Add(3);
+            test.Add(3);
+
+            TestEquivalent(test, control);
+
+            control.Add(3);
+            test.Add(3);
+
+            TestEquivalent(test, control);
+
+            control.Clear();
+            test.Clear();
+
+            TestEquivalent(test, control);
+        }
+    }
+}

--- a/src/Arch/Buffer/StructuralSparseSet.cs
+++ b/src/Arch/Buffer/StructuralSparseSet.cs
@@ -103,7 +103,7 @@ internal class StructuralSparseArray
     /// </summary>
     public void Clear()
     {
-        Array.Fill(Entities, -1, 0, Size);
+        Array.Fill(Entities, -1, 0, Entities.Length);
         Size = 0;
     }
 }


### PR DESCRIPTION
Currently, `StructuralSparseArray` is broken quite badly since the `Clear()` method doesn't empty the whole array.

Because of this, using Add and Remove in a reused CommandBuffer can occasionally corrupt the state of the world, by adding a component twice on an entity! The CommandBuffer needs to be recreated from scratch every time, because the `StructuralSparseArray` does not clear correctly.

This PR fixes the bug and adds a basic functionality test, testing operations against a control `HashSet`. The test currently fails on master, but passes after this PR.

I can't figure out how to reproduce the CommandBuffer bug for a unit test -- it only occurs in the wild after a very specific sequence of Add and Remove operations and playbacks, that I have yet to understand. But this fixes the root of the issue, regardless.