### PR TITLE
Fix off-by-one error when registering components and add missing version bump

### DIFF
--- a/src/Arch/Arch.csproj
+++ b/src/Arch/Arch.csproj
@@ -14,7 +14,7 @@
 
     <PackageId>Arch</PackageId>
     <Title>Arch</Title>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>genaray</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>A high performance c# net.7 and net.8 archetype based ECS ( Entity component system ).</Description>

--- a/src/Arch/Buffer/SparseSet.cs
+++ b/src/Arch/Buffer/SparseSet.cs
@@ -1,5 +1,5 @@
 using Arch.Core;
-using Arch.Core.Utils;
+using Arch.Core.Extensions.Internal;
 
 namespace Arch.Buffer;
 
@@ -88,9 +88,8 @@ internal class SparseArray
             if (index >= Capacity)
             {
                 // Calculate new array size that fits the passed index
-                var amountOfMultiplications = (int)Math.Ceiling(Math.Log((index+1) / (float)Capacity, 2.0f));
-                var newLength = (int)Math.Pow(2, amountOfMultiplications) * Capacity;
-                newLength = Math.Max(Capacity, newLength+1);
+                var newCapacity = MathExtensions.NextPowerOfTwo(index + 1);
+                var newLength = Math.Max(Capacity, newCapacity); // keep existing capacity if already larger
 
                 // Resize entities array
                 Array.Resize(ref Entities, newLength);

--- a/src/Arch/Core/ComponentRegistry.cs
+++ b/src/Arch/Core/ComponentRegistry.cs
@@ -126,10 +126,9 @@ public static class ComponentRegistry
         }
 
         // Register and assign component id
-        var id = Size + 1;
-        meta = new ComponentType(id, typeSize);
+        meta = new ComponentType(Size, typeSize);
         _typeToComponentType.Add(type, meta);
-        _types = _types.Add(id, type);
+        _types = _types.Add(Size, type);
 
         Size++;
         return meta;

--- a/src/Arch/Core/Edges/World.Edges.cs
+++ b/src/Arch/Core/Edges/World.Edges.cs
@@ -16,7 +16,7 @@ public partial class World
     private Archetype GetOrCreateArchetypeByAddEdge(in ComponentType type, Archetype oldArchetype)
     {
         Archetype archetype;
-        var edgeIndex = type.Id - 1;
+        var edgeIndex = type.Id;
 
         if (!oldArchetype.HasAddEdge(edgeIndex))
         {
@@ -42,7 +42,7 @@ public partial class World
     private Archetype GetOrCreateArchetypeByRemoveEdge(in ComponentType type, Archetype oldArchetype)
     {
         Archetype archetype;
-        var edgeIndex = type.Id - 1;
+        var edgeIndex = type.Id;
 
         if (!oldArchetype.HasRemoveEdge(edgeIndex))
         {

--- a/src/Arch/Core/Extensions/Internal/MathExtensions.cs
+++ b/src/Arch/Core/Extensions/Internal/MathExtensions.cs
@@ -17,4 +17,22 @@ internal static class MathExtensions
     {
         return a - ((a - b) & ((a - b) >> 31));
     }
+
+
+    public static int NextPowerOfTwo(int x)
+    {
+        if (x <= 1)
+        {
+            return 1;
+        }
+
+        x--;
+        x |= x >> 1;
+        x |= x >> 2;
+        x |= x >> 4;
+        x |= x >> 8;
+        x |= x >> 16;
+        x++;
+        return x;
+    }
 }


### PR DESCRIPTION
The component registry was incrementing the size twice, causing the 0th element to be null. Now it only increments after assigning.

Also, the version on the csproj was mismatched, causing local builds to generate an incorrect nupkg version. 