### PR TITLE
[WIP] Add component-level dirty/changed flags 

### DIFF
--- a/src/Arch/Arch.csproj
+++ b/src/Arch/Arch.csproj
@@ -590,6 +590,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>World.CreateBulk.tt</DependentUpon>
     </Compile>
+    <Compile Update="Templates\QueryDescription.WithDirty.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>QueryDescription.WithDirty.tt</DependentUpon>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/Arch/Arch.csproj
+++ b/src/Arch/Arch.csproj
@@ -41,29 +41,29 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>TRACE;</DefineConstants>
+    <DefineConstants>TRACE;DIRTY_FLAGS;</DefineConstants>
     <Optimize>false</Optimize>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug-PureECS'">
-    <DefineConstants>TRACE;PURE_ECS;</DefineConstants>
+    <DefineConstants>TRACE;PURE_ECS;DIRTY_FLAGS;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug-Events'">
-    <DefineConstants>TRACE;EVENTS;</DefineConstants>
+    <DefineConstants>TRACE;EVENTS;DIRTY_FLAGS;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;DIRTY_FLAGS;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release-Events'">
-    <DefineConstants>TRACE;EVENTS;</DefineConstants>
+    <DefineConstants>TRACE;EVENTS;DIRTY_FLAGS;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release-PureECS'">
-    <DefineConstants>TRACE;PURE_ECS</DefineConstants>
+    <DefineConstants>TRACE;PURE_ECS;DIRTY_FLAGS;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -958,3 +958,68 @@ public sealed partial class Archetype
         Chunk.CopyComponents(ref oldChunk, fromSlot.Index, ref sourceSignature, ref newChunk, toSlot.Index, 1);
     }
 }
+
+
+#if DIRTY_FLAGS
+
+public sealed partial class Archetype
+{
+    /// <summary>
+    /// Flags the component of an <see cref="Arch.Core.Entity"/> at a given <see cref="Slot"/> as dirty.
+    /// </summary>
+    /// <param name="slot">The <see cref="Slot"/> at which the component of an <see cref="Arch.Core.Entity"/> is to be marked dirty.</param>
+    /// <param name="componentType">The component type.</param>
+    internal void SetDirty(ref Slot slot, ComponentType componentType)
+    {
+        ref var chunk = ref GetChunk(slot.ChunkIndex);
+        chunk.SetDirty(slot.Index, componentType);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag of the component of an <see cref="Arch.Core.Entity"/> at a given <see cref="Slot"/>.
+    /// </summary>
+    /// <param name="slot">The <see cref="Slot"/> at which the component of an <see cref="Arch.Core.Entity"/> is to be cleared.</param>
+    /// <param name="componentType">The component type.</param>
+    internal void ClearDirty(ref Slot slot, ComponentType componentType)
+    {
+        ref var chunk = ref GetChunk(slot.ChunkIndex);
+        chunk.ClearDirty(slot.Index, componentType);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag for all components of an <see cref="Arch.Core.Entity"/> at a given <see cref="Slot"/>.
+    /// </summary>
+    /// <param name="slot">The slot.</param>
+    internal void ClearDirty(ref Slot slot)
+    {
+        ref var chunk = ref GetChunk(slot.ChunkIndex);
+        chunk.ClearDirty(slot.Index);
+    }
+
+    /// <summary>
+    /// Clears all the dirty flags in this Archetype.
+    /// </summary>
+    internal void ClearAllDirty()
+    {
+        for (var i = 0; i < Chunks.Count; i++)
+        {
+            ref var chunk = ref Chunks[i];
+            chunk.ClearAllDirty();
+        }
+    }
+
+    /// <summary>
+    /// Clears all the dirty flags for the specified component type in this Archetype.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    internal void ClearDirty(ComponentType type)
+    {
+        for (var i = 0; i < Chunks.Count; i++)
+        {
+            ref var chunk = ref Chunks[i];
+            chunk.ClearAllDirty(type);
+        }
+    }
+}
+
+#endif

--- a/src/Arch/Core/Archetype.cs
+++ b/src/Arch/Core/Archetype.cs
@@ -436,7 +436,7 @@ public sealed partial class Archetype
         ref var currentChunk = ref GetChunk(count);
 
         // Fill chunk
-        if (currentChunk.IsEmpty)
+        if (!currentChunk.IsFull)
         {
             slot = new Slot(currentChunk.Add(entity), count);
             chunk = currentChunk;

--- a/src/Arch/Core/Chunk.cs
+++ b/src/Arch/Core/Chunk.cs
@@ -675,37 +675,22 @@ public partial struct Chunk
     public readonly BitSet[] DirtyFlags { [Pure] get; }
 
     /// <summary>
-    /// Checks whether any component in this chunk has been marked dirty.
+    /// Checks whether any component of the given type has been flagged dirty.
     /// </summary>
-    /// <returns>True if it has, otherwise false</returns>
-    public bool IsDirty()
-    {
-        for (int i = 0; i < Components.Length; i++)
-        {
-            if (DirtyFlags.DangerousGetReferenceAt(i).IsAnyBitSet())
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Checks whether any component of the given type has been marked dirty.
-    /// </summary>
-    /// <param name="type">The component type to check</param>
-    /// <returns>True if it has, otherwise false</returns>
-    public bool IsDirty(ComponentType type)
+    /// <param name="type">The component type.</param>
+    /// <returns>True if the component is dirty, false otherwise.</returns>
+    public bool IsAnyDirty(ComponentType type)
     {
         var compIndex = Index(type);
         return DirtyFlags.DangerousGetReferenceAt(compIndex).IsAnyBitSet();
     }
 
     /// <summary>
-    /// Checks whether the component at the given index has been marked dirty.
+    /// Checks whether the component at the given index has been flagged dirty.
     /// </summary>
-    /// <returns>True if it has, otherwise false</returns>
+    /// <param name="index">The index.</param>
+    /// <param name="type">The component type.</param>
+    /// <returns>True if the component is dirty, false otherwise.</returns>
     public bool IsDirty(int index, ComponentType type)
     {
         var compIndex = Index(type);
@@ -713,42 +698,45 @@ public partial struct Chunk
     }
 
     /// <summary>
-    /// Set the dirty flags of the specified component type for all indices in this chunk.
+    /// Flags the specified component type as dirty, for all indices in this chunk.
     /// </summary>
     /// <param name="type">The type.</param>
-    public void SetDirty(ComponentType type)
+    public void SetAllDirty(ComponentType type)
     {
+        // TODO add a single per-component flag to avoid setting and clearing all the bits
         var index = Index(type);
         DirtyFlags.DangerousGetReferenceAt(index).SetAll();
     }
 
     /// <summary>
-    /// Set the dirty flags of the specified component type for all indices in this chunk.
+    /// Flags the component at the given index as dirty.
     /// </summary>
-    /// <param name="type">The type.</param>
     /// <param name="index">The index.</param>
+    /// <param name="type">The component type.</param>
     public void SetDirty(int index, ComponentType type)
     {
+        // TODO add a single per-component flag to avoid setting and clearing all the bits
         var compIndex = Index(type);
         DirtyFlags.DangerousGetReferenceAt(compIndex).SetBit(index);
     }
 
     /// <summary>
-    /// Clears all dirty flags in this chunk.
+    /// Clears all the dirty flags in this Chunk.
     /// </summary>
-    public void ClearDirty()
+    public void ClearAllDirty()
     {
-        foreach (var flags in DirtyFlags)
+        for (var i = 0; i < DirtyFlags.Length; i++)
         {
+            var flags = DirtyFlags.DangerousGetReferenceAt(i);
             flags.ClearAll();
         }
     }
 
     /// <summary>
-    /// Clears all dirty flags for the specified component type.
+    /// Clears all the dirty flags for the specified component type in this Chunk.
     /// </summary>
     /// <param name="type">The type.</param>
-    public void ClearDirty(ComponentType type)
+    public void ClearAllDirty(ComponentType type)
     {
         var index = Index(type);
         DirtyFlags.DangerousGetReferenceAt(index).ClearAll();
@@ -763,6 +751,19 @@ public partial struct Chunk
     {
         var compIndex = Index(type);
         DirtyFlags.DangerousGetReferenceAt(compIndex).ClearBit(index);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag for all components at the specified index.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    public void ClearDirty(int index)
+    {
+        for (var i = 0; i < DirtyFlags.Length; i++)
+        {
+            var flags = DirtyFlags.DangerousGetReferenceAt(i);
+            flags.ClearBit(index);
+        }
     }
 }
 

--- a/src/Arch/Core/Enumerators.cs
+++ b/src/Arch/Core/Enumerators.cs
@@ -171,7 +171,7 @@ public readonly ref struct QueryArchetypeIterator
 ///     represents an enumerator with which one can iterate over all non empty <see cref="Chunk"/>'s that matches the given <see cref="Query"/>.
 /// </summary>
 [SkipLocalsInit]
-public ref struct QueryChunkEnumerator
+public ref partial struct QueryChunkEnumerator
 {
     private QueryArchetypeEnumerator _archetypeEnumerator;
     private int _index;
@@ -538,4 +538,3 @@ public readonly ref struct RangePartitioner
         return new RangeEnumerator(_threads, _size);
     }
 }
-

--- a/src/Arch/Core/Extensions/EntityExtensions.cs
+++ b/src/Arch/Core/Extensions/EntityExtensions.cs
@@ -359,3 +359,46 @@ public static partial class EntityExtensions
 
 #endif
 }
+
+public static partial class EntityExtensions
+{
+
+#if DIRTY_FLAGS && !PURE_ECS
+
+    /// <inheritdoc cref="World.SetDirty&lt;T&gt;(Entity)"/>
+    public static void SetDirty<T>(this Entity entity)
+    {
+        var world = World.Worlds.DangerousGetReferenceAt(entity.WorldId);
+        world.SetDirty<T>(entity);
+    }
+
+    /// <inheritdoc cref="World.SetDirty(Entity, ComponentType)"/>
+    public static void SetDirty(this Entity entity, ComponentType componentType)
+    {
+        var world = World.Worlds.DangerousGetReferenceAt(entity.WorldId);
+        world.SetDirty(entity, componentType);
+    }
+
+    /// <inheritdoc cref="World.ClearDirty&lt;T&gt;(Entity)"/>
+    public static void ClearDirty<T>(this Entity entity)
+    {
+        var world = World.Worlds.DangerousGetReferenceAt(entity.WorldId);
+        world.ClearDirty<T>(entity);
+    }
+
+    /// <inheritdoc cref="World.ClearDirty(Entity, ComponentType)"/>
+    public static void ClearDirty(this Entity entity, ComponentType componentType)
+    {
+        var world = World.Worlds.DangerousGetReferenceAt(entity.WorldId);
+        world.ClearDirty(entity, componentType);
+    }
+
+    /// <inheritdoc cref="World.ClearDirty(Entity)"/>
+    public static void ClearDirty(this Entity entity)
+    {
+        var world = World.Worlds.DangerousGetReferenceAt(entity.WorldId);
+        world.ClearDirty(entity);
+    }
+
+#endif
+}

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -24,7 +24,7 @@ public sealed class BitSet
 
     public static int RequiredLength(int id)
     {
-#if NET7_0
+#if NET7_0_OR_GREATER
         return (id >> 5) + int.Sign(id & BitSize);
 #else
         return (int)Math.Ceiling((float)id / BitSize);
@@ -36,17 +36,15 @@ public sealed class BitSet
     /// </summary>
     private uint[] _bits;
 
-    /// TODO: Update on ClearBit, however clearbit is only used in tests so its fine for now.
     /// <summary>
     ///     The highest bit set.
     /// </summary>
     private int _highestBit;
 
-    /// TODO: Update on ClearBit, probably remove <see cref="_highestBit"/> in favor?
     /// <summary>
     ///     The maximum <see cref="_bits"/>-index current in use.
     /// </summary>
-    private int _max;
+    private int _max; // TODO: probably remove <see cref="_highestBit"/> in favor?
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="BitSet" /> class.
@@ -54,6 +52,21 @@ public sealed class BitSet
     public BitSet()
     {
         _bits = new uint[_padding];
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="BitSet" /> class with the required capacity.
+    /// </summary>
+    /// <param name="capacity">The initial capacity.</param>
+    public BitSet(int capacity)
+    {
+        // Calculate the number of uint blocks needed for 'capacity' bits
+        // Each block holds BitSize + 1 bits (usually 32)
+        int requiredBlocks = (capacity + BitSize) / (BitSize + 1);
+
+        // Round up to nearest multiple of _padding
+        int size = (requiredBlocks + _padding - 1) / _padding * _padding;
+        _bits = new uint[size];
     }
 
     /// <summary>
@@ -105,6 +118,15 @@ public sealed class BitSet
     }
 
     /// <summary>
+    /// Checks whether any bit is set.
+    /// </summary>
+    /// <returns>True if it is, otherwise false</returns>
+    public bool IsAnyBitSet()
+    {
+        return _highestBit >= 0;
+    }
+
+    /// <summary>
     ///     Sets a bit at the given index.
     ///     Resizes its internal array if necessary.
     /// </summary>
@@ -136,6 +158,47 @@ public sealed class BitSet
         }
 
         _bits[b] &= ~(1u << (index & BitSize));
+
+        // Update _highestBit and _max only if we cleared the previous highest bit
+        if (index != _highestBit)
+        {
+            return;
+        }
+
+        for (int i = _bits.Length - 1; i >= 0; i--)
+        {
+            uint val = _bits[i];
+            if (val != 0)
+            {
+
+#if NET7_0_OR_GREATER
+
+                // Compute highest set bit using LeadingZeroCount
+                int highestInBlock = BitSize - BitOperations.LeadingZeroCount(val) + 1;
+                _highestBit = (i << IndexSize) + (highestInBlock - 1);
+                _max = (_highestBit / (BitSize + 1)) + 1;
+                return;
+
+#else
+                    // Find the highest set bit in this block
+                    int bitPos = BitSize; // usually 31
+                    while (bitPos >= 0)
+                    {
+                        if ((val & (1u << bitPos)) != 0)
+                        {
+                            _highestBit = (i << IndexSize) + bitPos;
+                            _max = (_highestBit / (BitSize + 1)) + 1;
+                            return;
+                        }
+                        bitPos--;
+                    }
+#endif
+            }
+        }
+
+        // No bits left
+        _highestBit = -1;
+        _max = 0;
     }
 
     /// <summary>
@@ -159,6 +222,8 @@ public sealed class BitSet
     public void ClearAll()
     {
         Array.Clear(_bits, 0, _bits.Length);
+        _highestBit = -1;
+        _max = 0;
     }
 
     /// <summary>

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -1745,3 +1745,66 @@ public partial class World
 }
 
 #endregion
+
+#if DIRTY_FLAGS
+
+public partial class World
+{
+    /// <summary>
+    /// Flags the component of type an <see cref="Arch.Core.Entity"/> as dirty.
+    /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="entity">The <see cref="Entity"/>.</param>
+    public void SetDirty<T>(Entity entity)
+    {
+        var componentType = Component<T>.ComponentType;
+        var entityData = EntityInfo.GetEntityData(entity.Id);
+        entityData.Archetype.SetDirty(ref entityData.Slot, componentType);
+    }
+
+    /// <summary>
+    /// Flags the component of type an <see cref="Arch.Core.Entity"/> as dirty.
+    /// </summary>
+    /// <param name="entity">The <see cref="Entity"/>.</param>
+    /// <param name="type">The component <see cref="ComponentType"/>.</param>
+    public void SetDirty(Entity entity, ComponentType type)
+    {
+        var entityData = EntityInfo.GetEntityData(entity.Id);
+        entityData.Archetype.SetDirty(ref entityData.Slot, type);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag of the component of an <see cref="Arch.Core.Entity"/>.
+    /// </summary>
+    /// <typeparam name="T">The component type.</typeparam>
+    /// <param name="entity">The <see cref="Entity"/>.</param>
+    public void ClearDirty<T>(Entity entity)
+    {
+        var componentType = Component<T>.ComponentType;
+        var entityData = EntityInfo.GetEntityData(entity.Id);
+        entityData.Archetype.ClearDirty(ref entityData.Slot, componentType);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag of the component of an <see cref="Arch.Core.Entity"/>.
+    /// </summary>
+    /// <param name="entity">The <see cref="Entity"/>.</param>
+    /// <param name="type">The component <see cref="ComponentType"/>.</param>
+    public void ClearDirty(Entity entity, ComponentType type)
+    {
+        var entityData = EntityInfo.GetEntityData(entity.Id);
+        entityData.Archetype.ClearDirty(ref entityData.Slot, type);
+    }
+
+    /// <summary>
+    /// Clears the dirty flag for all components of an <see cref="Arch.Core.Entity"/>.
+    /// </summary>
+    /// <param name="entity">The <see cref="Entity"/>.</param>
+    public void ClearDirty(Entity entity)
+    {
+        var entityData = EntityInfo.GetEntityData(entity.Id);
+        entityData.Archetype.ClearDirty(ref entityData.Slot);
+    }
+}
+
+#endif

--- a/src/Arch/Templates/QueryDescription.WithDirty.cs
+++ b/src/Arch/Templates/QueryDescription.WithDirty.cs
@@ -1,0 +1,204 @@
+﻿
+
+using System;
+using System.Diagnostics.Contracts;
+using Arch.Core;
+using Arch.Core.Utils;
+
+namespace Arch.Core;
+public partial struct QueryDescription
+{
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1>()
+    {
+        All = Component<T0, T1>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2>()
+    {
+        All = Component<T0, T1, T2>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3>()
+    {
+        All = Component<T0, T1, T2, T3>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4>()
+    {
+        All = Component<T0, T1, T2, T3, T4>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>.Signature;
+        Build();
+        return ref this;
+    }
+    
+    [UnscopedRef]
+    public ref QueryDescription WithAll<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>()
+    {
+        All = Component<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>.Signature;
+        Build();
+        return ref this;
+    }
+    }
+

--- a/src/Arch/Templates/QueryDescription.WithDirty.tt
+++ b/src/Arch/Templates/QueryDescription.WithDirty.tt
@@ -1,0 +1,33 @@
+<#@ template language="C#" #>
+<#@ output extension=".cs" #>
+<#@ import namespace="System.Text" #>
+<#@ include file="Helpers.ttinclude" #>
+
+using System;
+using System.Diagnostics.Contracts;
+using Arch.Core;
+using Arch.Core.Utils;
+
+namespace Arch.Core;
+public partial struct QueryDescription
+{
+#if DIRTY_FLAGS
+    <#
+    for (var index = 2; index <= Amount; index++)
+    {
+        var generics = AppendGenerics(index);
+    #>
+
+    [UnscopedRef]
+    public ref QueryDescription WithDirty<<#= generics #>>()
+    {
+        All = Component<<#= generics #>>.Signature;
+        Build();
+        return ref this;
+    }
+    <#
+    }
+    #>
+#endif
+}
+


### PR DESCRIPTION
Adds the ability to flag entities as dirty on a per-component basis. This can be done manually by calling `entity.SetDirty<MyComponentType>()` or (coming soon) automatically when a query potentially modifies it.


It works by storing a BitSet for each component type inside each chunk. 

It's behind a compile-time flag and even when enabled, it should have minimal cpu and memory overhead when unused.

Future work:

- [ ] Finish dirty-filtering in queries
- [ ] Add automatic dirtying to queries that write to a component
- [ ] Add a single chunk-level flag to speed up dirty checking