### PR TITLE
Fix SparseArray capacity bug and remove dead code in BitSet.Any

### DIFF
--- a/src/Arch/Buffer/SparseSet.cs
+++ b/src/Arch/Buffer/SparseSet.cs
@@ -285,7 +285,7 @@ internal class SparseSet
 
     private void AddSparseArray(ComponentType type)
     {
-        Components[type.Id] = new SparseArray(type, type.Id);
+        Components[type.Id] = new SparseArray(type, Capacity);
 
         Used[UsedSize] = type.Id;
         UsedSize++;

--- a/src/Arch/Core/Utils/BitSet.cs
+++ b/src/Arch/Core/Utils/BitSet.cs
@@ -246,14 +246,6 @@ public sealed class BitSet
                 }
             }
 
-            // Handle extra bits on our side that might just be all zero.
-            for (var i = min; i < _max; i++)
-            {
-                if (bits[i] > 0)
-                {
-                    return false;
-                }
-            }
         }
         else
         {
@@ -270,15 +262,6 @@ public sealed class BitSet
                 }
             }
 
-            // Handle extra bits on our side that might just be all zero.
-            for (var i = min; i < _max; i += _padding)
-            {
-                var vector = new Vector<uint>(_bits, i);
-                if (!Vector.EqualsAll(vector, Vector<uint>.Zero)) // Vectors are not zero bits[0] != 0 basically
-                {
-                    return false;
-                }
-            }
         }
 
         return _highestBit <= 0;


### PR DESCRIPTION
- SparseSet.AddSparseArray: pass Capacity instead of type.Id to SparseArray constructor. 
  Matches how StructuralSparseSet does it.
- BitSet.Any: remove two redundant loops over [min, _max). If this BitSet has bits set 
  in that range, _highestBit is already > 0, so the final return yields false regardless.