### PR TITLE
Throw instead of silently corrupting data on a same-archetype move (completes #216)

### DIFF
--- a/src/Arch.Benchmarks/AddRemoveBenchmark.cs
+++ b/src/Arch.Benchmarks/AddRemoveBenchmark.cs
@@ -1,45 +1,55 @@
-﻿using Arch.Core;
+using Arch.Core;
+using Arch.Core.Utils;
 
 namespace Arch.Benchmarks;
 
+/// <summary>
+///     Measures the cost of the same-archetype guard in <see cref="World.Move"/> on the
+///     success path. A valid add + remove round-trip pays the guard's single reference
+///     comparison (<c>source == destination</c>) on already-computed archetypes but never
+///     takes the throwing branch, so this quantifies the overhead the safety check adds to
+///     normal structural changes.
+/// </summary>
 [HtmlExporter]
 [MemoryDiagnoser]
 public class AddRemoveBenchmark
 {
-    [Params(10000, 100000, 1000000)] public int Amount;
+    [Params(10000, 100000)] public int Amount;
 
-    private static World _world;
-    private static List<Entity> _entities;
+    private static readonly ComponentType[] _group = { typeof(Transform) };
+
+    private World _world = null!;
+    private Entity[] _entities = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         _world = World.Create();
+        _world.Reserve(_group, Amount);
 
-        _entities = new List<Entity>(Amount);
+        _entities = new Entity[Amount];
         for (var index = 0; index < Amount; index++)
         {
-            _entities.Add(_world.Create(new Transform(), new Velocity()));
+            _entities[index] = _world.Create(_group);
         }
     }
 
-    [Benchmark]
-    public void Add()
+    [GlobalCleanup]
+    public void Cleanup()
     {
-        for (var index = 0; index < _entities.Count; index++)
-        {
-            var entity = _entities[index];
-            _world.Add<Position2D>(entity);
-        }
+        World.Destroy(_world);
     }
 
     [Benchmark]
-    public void Remove()
+    public void AddRemove()
     {
-        for (var index = 0; index < _entities.Count; index++)
+        var world = _world;
+        var entities = _entities;
+        for (var index = 0; index < entities.Length; index++)
         {
-            var entity = _entities[index];
-            _world.Remove<Transform>(entity);
+            var entity = entities[index];
+            world.Add<Velocity>(entity);
+            world.Remove<Velocity>(entity);
         }
     }
 }

--- a/src/Arch.Tests/CommandBufferTest.cs
+++ b/src/Arch.Tests/CommandBufferTest.cs
@@ -32,6 +32,45 @@ public sealed partial class CommandBufferTest
         That(rotation.X, Is.EqualTo(10));
     }
 
+    /// <summary>
+    ///     A deferred remove of a component the <see cref="Entity"/> does not have throws on
+    ///     <see cref="CommandBuffer.Playback"/> instead of silently corrupting a sibling's data
+    ///     via a move within the same archetype (see genaray/Arch#224).
+    /// </summary>
+    [Test]
+    public void CommandBufferRemoveNonExistentComponentThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_group);   // Ai is not present on this archetype
+
+        var commandBuffer = new CommandBuffer();
+        commandBuffer.Remove<Ai>(in entity);
+
+        Throws<InvalidOperationException>(() => commandBuffer.Playback(world));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     A deferred add of a component the <see cref="Entity"/> already has throws on
+    ///     <see cref="CommandBuffer.Playback"/> rather than silently moving within the archetype.
+    /// </summary>
+    [Test]
+    public void CommandBufferAddExistingComponentThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_group);   // already has Transform
+
+        var commandBuffer = new CommandBuffer();
+        commandBuffer.Add(in entity, new Transform());
+
+        Throws<InvalidOperationException>(() => commandBuffer.Playback(world));
+
+        World.Destroy(world);
+    }
+
     [Test]
     public void CommandBufferForExistingEntity()
     {

--- a/src/Arch.Tests/WorldTest.cs
+++ b/src/Arch.Tests/WorldTest.cs
@@ -932,3 +932,191 @@ public partial class WorldTest
         }
     }
 }
+
+
+// Structural safety checks: adding a component an entity already has, or removing one it
+// does not, keeps the source archetype. Such an operation must not move the entity within
+// the same archetype — that duplicated it into a second slot and silently corrupted its
+// siblings. It now throws instead, and the world is left untouched.
+public partial class WorldTest
+{
+    /// <summary>
+    ///     Removing a component an <see cref="Entity"/> does not have throws instead of
+    ///     silently corrupting sibling data, and leaves every entity untouched.
+    /// </summary>
+    [Test]
+    public void RemoveNonExistentComponentThrows()
+    {
+        var world = World.Create();
+
+        var first = world.Create(_entityGroup);
+        var second = world.Create(_entityGroup);
+        world.Set(first, new Transform { X = 1, Y = 1 });
+        world.Set(second, new Transform { X = 2, Y = 2 });
+
+        // Ai is present on neither entity.
+        Throws<InvalidOperationException>(() => world.Remove<Ai>(first));
+
+        // The world is untouched: no entity was moved and no sibling data was corrupted.
+        True(world.Has<Transform>(first));
+        True(world.Has<Transform>(second));
+        That(world.Get<Transform>(first).X, Is.EqualTo(1));
+        That(world.Get<Transform>(second).X, Is.EqualTo(2));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     Adding a component an <see cref="Entity"/> already has throws instead of silently
+    ///     corrupting sibling data. Same corruption path as
+    ///     <see cref="RemoveNonExistentComponentThrows"/>.
+    /// </summary>
+    [Test]
+    public void AddExistingComponentThrows()
+    {
+        var world = World.Create();
+
+        var first = world.Create(_entityGroup);
+        var second = world.Create(_entityGroup);
+        world.Set(first, new Transform { X = 1, Y = 1 });
+        world.Set(second, new Transform { X = 2, Y = 2 });
+
+        // Transform is already present on both entities.
+        Throws<InvalidOperationException>(() => world.Add<Transform>(first));
+
+        That(world.Get<Transform>(first).X, Is.EqualTo(1));
+        That(world.Get<Transform>(second).X, Is.EqualTo(2));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     The non-generic <see cref="World.Remove(Entity, ComponentType)"/> also throws when
+    ///     the component is absent.
+    /// </summary>
+    [Test]
+    public void RemoveNonExistentComponentNonGenericThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);
+        Throws<InvalidOperationException>(() => world.Remove(entity, typeof(Ai)));
+
+        True(world.Has<Transform>(entity));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     Removing an empty span of components is a legitimate no-op and must not throw or
+    ///     move the entity within its archetype (see genaray/Arch#253).
+    /// </summary>
+    [Test]
+    public void RemoveRangeEmptyIsNoOp()
+    {
+        var world = World.Create();
+
+        var first = world.Create(_entityGroup);
+        var second = world.Create(_entityGroup);
+        world.Set(first, new Transform { X = 1, Y = 1 });
+        world.Set(second, new Transform { X = 2, Y = 2 });
+
+        DoesNotThrow(() => world.RemoveRange(first, Span<ComponentType>.Empty));
+
+        That(world.Get<Transform>(first).X, Is.EqualTo(1));
+        That(world.Get<Transform>(second).X, Is.EqualTo(2));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     The non-generic <see cref="World.Add(Entity, in object)"/> also throws when the
+    ///     component is already present.
+    /// </summary>
+    [Test]
+    public void AddExistingComponentNonGenericThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);   // already has Transform
+        Throws<InvalidOperationException>(() => world.Add(entity, (object)new Transform()));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     The source-generated variadic <c>Add&lt;T0, T1&gt;</c> throws when every component is
+    ///     already present (it funnels through the same guarded move).
+    /// </summary>
+    [Test]
+    public void AddExistingComponentsGeneratedThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);   // already has Transform and Rotation
+        Throws<InvalidOperationException>(() => world.Add<Transform, Rotation>(entity));
+
+        World.Destroy(world);
+    }
+
+#if !EVENTS
+    /// <summary>
+    ///     The source-generated variadic <c>Remove&lt;T0, T1&gt;</c> throws when none of the
+    ///     components are present.
+    ///
+    ///     Excluded under EVENTS: the generated remove fires
+    ///     <c>OnComponentRemoved&lt;T&gt;(entity)</c> before <c>Move</c>, and that hook reads
+    ///     the removed value via <c>Get&lt;T&gt;(entity)</c> unconditionally — on an entity
+    ///     that does not have the component this is the pre-existing Get-of-absent hazard
+    ///     (the other half of #216) and crashes with an AccessViolation before this guard
+    ///     is ever reached. Reproducible on master without this change.
+    /// </summary>
+    [Test]
+    public void RemoveNonExistentComponentsGeneratedThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);   // has neither Ai nor int
+        Throws<InvalidOperationException>(() => world.Remove<Ai, int>(entity));
+
+        True(world.Has<Transform>(entity));
+
+        World.Destroy(world);
+    }
+#endif
+
+    /// <summary>
+    ///     <see cref="World.AddRange(Entity, Span{object})"/> throws when the components are
+    ///     already present.
+    /// </summary>
+    [Test]
+    public void AddRangeExistingComponentsThrows()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);   // already has Transform
+        var components = new object[] { new Transform() };
+        Throws<InvalidOperationException>(() => world.AddRange(entity, components));
+
+        World.Destroy(world);
+    }
+
+    /// <summary>
+    ///     Adding an empty span of components is a legitimate no-op and must not throw, for
+    ///     both the object and <see cref="ComponentType"/> overloads.
+    /// </summary>
+    [Test]
+    public void AddRangeEmptyIsNoOp()
+    {
+        var world = World.Create();
+
+        var entity = world.Create(_entityGroup);
+        DoesNotThrow(() => world.AddRange(entity, Span<object>.Empty));
+        DoesNotThrow(() => world.AddRange(entity, Span<ComponentType>.Empty));
+
+        True(world.Has<Transform>(entity));
+        True(world.Has<Rotation>(entity));
+
+        World.Destroy(world);
+    }
+}

--- a/src/Arch/Buffer/CommandBuffer.cs
+++ b/src/Arch/Buffer/CommandBuffer.cs
@@ -276,6 +276,10 @@ public sealed partial class CommandBuffer : IDisposable
     /// </summary>
     /// <remarks>
     ///     This operation should only happen on the main thread.
+    ///     Playback is not atomic: commands are applied in phases with no rollback, so an
+    ///     invalid command (e.g. adding a component an entity already has or removing one it
+    ///     does not) throws mid-playback and leaves earlier phases applied. Do not reuse a
+    ///     buffer whose playback threw.
     /// </remarks>
     /// <param name="world">The <see cref="World"/> where the commands will be playbacked too.</param>
     /// <param name="dispose">If true it will clear the recorded operations after they were playbacked, if not they will stay.</param>

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -327,8 +327,15 @@ public partial class World : IDisposable
         // Entity should match the supplied EntityData.
         Debug.Assert(entity == data.Archetype.Entity(ref data.Slot));
 
-        // A common mistake, happening in many cases.
-        Debug.Assert(source != destination, "From-Archetype is the same as the To-Archetype. Entities cannot move within the same archetype using this function. Probably an attempt was made to attach already existing components to the entity or to remove non-existing ones.");
+        // A same-archetype move duplicates the entity into a second slot and corrupts a
+        // sibling's data. Guarded at runtime because the old Debug.Assert vanished in Release.
+        if (source == destination)
+        {
+            throw new InvalidOperationException(
+                "The operation would move the entity within the same archetype, which is not allowed. " +
+                "This happens when a component is added to an entity that already has it, or removed from " +
+                "one that does not. Check with Has<T>() before adding or removing the component.");
+        }
 
         // Copy entity to other archetype
         var slot = data.Slot;
@@ -1466,6 +1473,12 @@ public partial class World
     [StructuralChange]
     public void AddRange(Entity entity, Span<object> components)
     {
+        // Adding no components changes nothing and must not attempt a same-archetype move.
+        if (components.Length == 0)
+        {
+            return;
+        }
+
         ref var data = ref EntityInfo.EntityData[entity.Id];
         var oldArchetype = data.Archetype;
 
@@ -1516,6 +1529,12 @@ public partial class World
     [StructuralChange]
     public void AddRange(Entity entity, Span<ComponentType> components)
     {
+        // Adding no components changes nothing and must not attempt a same-archetype move.
+        if (components.Length == 0)
+        {
+            return;
+        }
+
         ref var data = ref EntityInfo.EntityData[entity.Id];
         var oldArchetype = data.Archetype;
 
@@ -1591,6 +1610,12 @@ public partial class World
     [StructuralChange]
     public void RemoveRange(Entity entity, Span<ComponentType> types)
     {
+        // Removing no components changes nothing and must not attempt a same-archetype move.
+        if (types.Length == 0)
+        {
+            return;
+        }
+
         ref var data = ref EntityInfo.EntityData[entity.Id];
         var oldArchetype = data.Archetype;
 


### PR DESCRIPTION

### Problem

A structural operation that does not actually change an entity's component set
silently corrupts *other* entities' data in Release builds:

- `Remove<T>` / `Remove(type)` where the entity does **not** have the component
- `Add<T>` / `Add(object)` where the entity **already** has it
- the `*Range` overloads of both
- the same operations recorded on a `CommandBuffer` and applied via `Playback`

When two such operations hit entities sharing an archetype, the affected
entities end up sharing the **last** one's data — no exception, no log. This
has been reported repeatedly: #305 (closed as "check before you remove"), #224
(CommandBuffer), and #253 (empty `RemoveRange`).

### Minimal repro (Release)

```csharp
var world = World.Create();
var a = world.Create(new Name { Value = "a" });
var b = world.Create(new Name { Value = "b" });
a.Remove<Absent>();     // neither entity has Absent
b.Remove<Absent>();
// a.Get<Name>().Value is now "b" — silently overwritten.
```

### Root cause

`GetOrCreateArchetypeBy{Add,Remove}Edge` return the **same** archetype when the
component set does not change, so every structural path calls
`World.Move(entity, source, destination)` with `source == destination`. `Move`
was only guarded by `Debug.Assert(source != destination, …)`, which is compiled
out of Release. Past the assert, `Move` does `destination.Add(entity, …)` — a
second slot for the same entity in the same archetype — then
`source.Remove(ref slot, …)`, which relocates the archetype's last entity into
the freed slot and tangles the bookkeeping, overwriting a sibling's data.

### Fix

Turn the compiled-out assertion into a real runtime check. This is exactly the
direction @genaray endorsed in #216 ("it's time to finally introduce safety
checks"); that PR stalled only on a requested benchmark, which this PR includes.

```csharp
// World.Move
if (source == destination)
{
    throw new InvalidOperationException(
        "The operation would move the entity within the same archetype, ...");
}
```

- One change covers every entry point because they all funnel through `Move`
  (direct, non-generic, `*Range`, and `CommandBuffer` playback).
- Thrown inline, matching the existing throws in the codebase. `Move` is already
  well past the JIT inlining threshold, so a separate `ThrowHelper` buys nothing
  here (unlike #216, which checked inside the small `Add`/`Remove`/`Get`/`Set`).
- Empty `AddRange` / `RemoveRange` are guarded as legitimate no-ops, so they no
  longer reach the check — this is the correct fix for the empty-span half of
  #253 (a no-op, not an error).

`Debug.Assert` is intentionally replaced rather than kept: it never protected
Release, which is where the corruption actually happened.

### Tests (net8.0, Debug + Release × Default / Events / PureECS — all green)

Throws, covering every structural entry point:
- `RemoveNonExistentComponentThrows` (`Remove<T>`)
- `AddExistingComponentThrows` (`Add<T>`)
- `RemoveNonExistentComponentNonGenericThrows` (`Remove(entity, type)`)
- `AddExistingComponentNonGenericThrows` (`Add(entity, object)`)
- `AddExistingComponentsGeneratedThrows` (source-generated `Add<T0,T1>`)
- `RemoveNonExistentComponentsGeneratedThrows` (source-generated `Remove<T0,T1>`)
- `AddRangeExistingComponentsThrows` (`AddRange`)
- `CommandBufferRemoveNonExistentComponentThrows` / `CommandBufferAddExistingComponentThrows` (deferred)

No-op guards (must NOT throw):
- `RemoveRangeEmptyIsNoOp` — pins #253's empty-span no-op
- `AddRangeEmptyIsNoOp` — both `Span<object>` and `Span<ComponentType>` overloads

Each corruption test fails before the fix (in Debug via the assert; in Release
via the actual sibling-data overwrite — confirmed: `a.X` read `2` instead of
`1`) and passes after. `Move` throws *before* any mutation, so a caught throw
leaves the world untouched (the tests assert siblings stay intact).

### Benchmark

Reworked the existing `AddRemoveBenchmark` into a valid add+remove round-trip —
the success path the guard adds a single `source == destination` reference
comparison to, on archetypes already computed by the existing edge lookup.

The check adds **no allocation** and its cost sits far below short-run
measurement noise (ShortRun margins were 20–170%). The comparison is one
reference equality on values already in hand, so no measurable regression is
expected on the structural-change path. Run a full job to confirm precisely:

```
dotnet run -c Release --project src/Arch.Benchmarks -- --filter *AddRemove*
```
(enable `BenchmarkSwitcher` in `Benchmark.cs` first — the repo ships it commented out).

### Scope & known limitations

Focused on the **data-corruption** path (structural Add/Remove). Semantics:
`InvalidOperationException`, matching #216 and your stated preference for
exceptions on public-API misuse.

Deliberately left as pre-existing / follow-up (out of scope here):
- **`*Range` at element granularity.** `RemoveRange([present, absent])` changes
  the archetype, so it does not hit the guard and the absent element is still
  silently ignored (and the `#if EVENTS` loops fire an event per element). The
  guard only catches the whole-operation no-op. A per-element check would be a
  separate change.
- **`Get`/`Set` of an absent component** (garbage read/write, not sibling
  corruption) — the other half of #216. Happy to fold in or leave as follow-up.
  Concretely: under an `EVENTS` build, the variadic `Remove<T0, T1>` fires
  `OnComponentRemoved<T>(entity)` *before* `Move`, and that hook reads the
  removed value via `Get<T>(entity)` unconditionally — remove-of-absent there
  crashes with an AccessViolation on **master today**, before this PR's guard
  is ever reached. The corresponding regression test is therefore excluded
  under `EVENTS` (`#if !EVENTS`, with a comment) rather than papered over.
- **`CommandBuffer.Playback` is not atomic.** A throw mid-playback leaves earlier
  phases applied; documented in the `Playback` XML doc ("do not reuse a buffer
  whose playback threw"). Under an `EVENTS` build, `OnComponentRemoved` fires
  before the guard throws, so "world untouched" is not fully honored there.

Completes #216. Fixes #224, #253. Addresses #305.
