### PR TITLE
Fix broken critical section in static World create/destroy

### DIFF
--- a/src/Arch.Tests/WorldConcurrencyTest.cs
+++ b/src/Arch.Tests/WorldConcurrencyTest.cs
@@ -1,0 +1,135 @@
+// The static World registry (World.Worlds / World.Create bookkeeping) does not exist
+// under PURE_ECS, and neither do the Entity extension methods used below.
+#if !PURE_ECS
+using Arch.Core;
+using Arch.Core.Extensions;
+using static NUnit.Framework.Assert;
+
+namespace Arch.Tests;
+
+/// <summary>
+///     The <see cref="WorldConcurrencyTest"/> class
+///     tests concurrent <see cref="World.Create()"/>/<see cref="World.Destroy"/> against the
+///     static <see cref="World.Worlds"/> storage.
+///
+///     Historically <c>World.Create</c> locked the <see cref="World.Worlds"/> array itself and
+///     replaced that array on resize, so after a resize concurrent creators locked different
+///     objects and raced: duplicate world ids, lost slot writes (a created world resolving to
+///     <c>null</c> through <c>World.Worlds[entity.WorldId]</c>) and cross-wired entity storage.
+/// </summary>
+[TestFixture]
+public sealed class WorldConcurrencyTest
+{
+    /// <summary>
+    ///     Concurrently creates worlds (forcing several <see cref="World.Worlds"/> resizes),
+    ///     uses each created world immediately and checks id uniqueness.
+    /// </summary>
+    [Test]
+    public void ConcurrentWorldCreateProducesUniqueUsableWorlds()
+    {
+        const int threads = 8;
+        const int worldsPerThread = 64;
+
+        var created = new World[threads * worldsPerThread];
+        using var barrier = new Barrier(threads);
+
+        RunOnThreads(threads, threadIndex =>
+        {
+            barrier.SignalAndWait();
+            for (var i = 0; i < worldsPerThread; i++)
+            {
+                var world = World.Create();
+                created[(threadIndex * worldsPerThread) + i] = world;
+
+                // Use the world through the static lookup right away — this is the read path
+                // (EntityExtensions/generated accessors) that observed null slots pre-fix.
+                var entity = world.Create(new Transform { X = threadIndex, Y = i });
+                That(entity.IsAlive(), Is.True);
+                That(entity.Get<Transform>().X, Is.EqualTo(threadIndex));
+            }
+        });
+
+        try
+        {
+            var ids = new HashSet<int>();
+            foreach (var world in created)
+            {
+                That(world, Is.Not.Null);
+                That(ids.Add(world.Id), Is.True, $"Duplicate world id {world.Id} handed out concurrently.");
+                That(World.Worlds[world.Id], Is.SameAs(world));
+            }
+        }
+        finally
+        {
+            foreach (var world in created)
+            {
+                if (world != null)
+                {
+                    World.Destroy(world);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Churns concurrent create → use → destroy cycles so id recycling, slot writes and
+    ///     resizes interleave across threads.
+    /// </summary>
+    [Test]
+    public void ConcurrentWorldCreateDestroyChurnDoesNotCorruptStaticStorage()
+    {
+        const int threads = 8;
+        const int rounds = 200;
+
+        using var barrier = new Barrier(threads);
+
+        RunOnThreads(threads, threadIndex =>
+        {
+            barrier.SignalAndWait();
+            for (var round = 0; round < rounds; round++)
+            {
+                var world = World.Create();
+                var entity = world.Create(new Transform { X = round, Y = threadIndex });
+                That(entity.Get<Transform>().Y, Is.EqualTo(threadIndex));
+                That(World.Worlds[world.Id], Is.SameAs(world));
+                World.Destroy(world);
+            }
+        });
+    }
+
+    private static void RunOnThreads(int threadCount, Action<int> body)
+    {
+        var failures = new List<Exception>();
+        var workers = new Thread[threadCount];
+        for (var t = 0; t < threadCount; t++)
+        {
+            var threadIndex = t;
+            workers[t] = new Thread(() =>
+            {
+                try
+                {
+                    body(threadIndex);
+                }
+                catch (Exception exception)
+                {
+                    lock (failures)
+                    {
+                        failures.Add(exception);
+                    }
+                }
+            });
+            workers[t].Start();
+        }
+
+        foreach (var worker in workers)
+        {
+            worker.Join();
+        }
+
+        if (failures.Count > 0)
+        {
+            throw new AggregateException(failures);
+        }
+    }
+}
+#endif

--- a/src/Arch.Tests/WorldTest.cs
+++ b/src/Arch.Tests/WorldTest.cs
@@ -48,11 +48,31 @@ public sealed partial class WorldTest
     [Test]
     public void WorldRecycle()
     {
-        var firstWorld = World.Create();
-        World.Destroy(firstWorld);
+        // Recycled ids are handed out FIFO, so drain the queue left behind by earlier
+        // world-churning tests to make the reuse check below deterministic. The queue can
+        // never hold more ids than the id space allocated so far, which Worlds.Length bounds.
+        var drained = new World[World.Worlds.Length];
+        for (var index = 0; index < drained.Length; index++)
+        {
+            drained[index] = World.Create();
+        }
 
-        var secondWorld = World.Create();
-        That(secondWorld.Id, Is.EqualTo(firstWorld.Id));
+        try
+        {
+            var firstWorld = World.Create();
+            World.Destroy(firstWorld);
+
+            var secondWorld = World.Create();
+            That(secondWorld.Id, Is.EqualTo(firstWorld.Id));
+            World.Destroy(secondWorld);
+        }
+        finally
+        {
+            foreach (var world in drained)
+            {
+                World.Destroy(world);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Arch/Core/World.cs
+++ b/src/Arch/Core/World.cs
@@ -72,7 +72,22 @@ public partial class World
     ///     A list of all existing <see cref="Worlds"/>.
     ///     Should not be modified by the user.
     /// </summary>
-    public static World[] Worlds { get; private set; } = new World[4];
+    public static World[] Worlds
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _worlds;
+    }
+
+    private static World[] _worlds = new World[4];
+
+    /// <summary>
+    ///     Guards <see cref="_worlds"/>, <see cref="RecycledWorldIds"/> and world id assignment.
+    ///     A dedicated lock object: locking the array itself is unsound because the array
+    ///     reference is replaced on resize, after which concurrent creators lock different
+    ///     objects and race — duplicate world ids and lost slot writes (NREs in
+    ///     <see cref="EntityExtensions"/>, AccessViolation in <see cref="Chunk"/>).
+    /// </summary>
+    private static readonly object WorldsLock = new();
 
     /// <summary>
     ///     Stores recycled <see cref="World"/> IDs.
@@ -106,23 +121,31 @@ public partial class World
 #if PURE_ECS
         return new World(-1, chunkSizeInBytes, minimumAmountOfEntitiesPerChunk, archetypeCapacity, entityCapacity);
 #else
-        lock (Worlds)
+        lock (WorldsLock)
         {
             var recycle = RecycledWorldIds.TryDequeue(out var id);
             var recycledId = recycle ? id : WorldSize;
 
             var world = new World(recycledId, chunkSizeInBytes, minimumAmountOfEntitiesPerChunk, archetypeCapacity, entityCapacity);
 
-            // If you need to ensure a higher capacity, you can manually check and increase it
-            if (recycledId >= Worlds.Length)
+            var worlds = _worlds;
+            if (recycledId >= worlds.Length)
             {
-                var newCapacity = Worlds.Length * 2;
-                var worlds = Worlds;
-                Array.Resize(ref worlds, newCapacity);
-                Worlds = worlds;
+                // Fill the slot in the copy before publishing the new array so readers
+                // (EntityExtensions and generated accessors index Worlds without a lock,
+                // and Entity handles carry an address dependency on the array reference)
+                // never observe a published array whose contents are not yet visible on
+                // weakly-ordered CPUs (ARM64).
+                var resized = new World[worlds.Length * 2];
+                Array.Copy(worlds, resized, worlds.Length);
+                resized[recycledId] = world;
+                Volatile.Write(ref _worlds, resized);
+            }
+            else
+            {
+                Volatile.Write(ref worlds[recycledId], world);
             }
 
-            Worlds[recycledId] = world;
             Interlocked.Increment(ref worldSizeUnsafe);
             return world;
         }
@@ -533,9 +556,9 @@ public partial class World : IDisposable
         _isDisposed = true;
         var world = this;
 #if !PURE_ECS
-        lock (Worlds)
+        lock (WorldsLock)
         {
-            Worlds[world.Id] = null!;
+            Volatile.Write(ref _worlds[world.Id], null!);
             RecycledWorldIds.Enqueue(world.Id);
             Interlocked.Decrement(ref worldSizeUnsafe);
         }


### PR DESCRIPTION

### Problem

`World.Create` and `World.Dispose` lock the static `Worlds` array itself, but
`Create` **replaces that array on resize**:

```csharp
lock (Worlds)
{
    ...
    if (recycledId >= Worlds.Length)
    {
        var worlds = Worlds;
        Array.Resize(ref worlds, newCapacity);
        Worlds = worlds;          // <- the lock target just changed
    }
    Worlds[recycledId] = world;
}
```

After a resize, a creator blocked on the **old** array's monitor and a newly
arriving creator locking the **new** array enter the critical section
concurrently. Two failure modes follow:

- both dequeue/compute the same world id → two live worlds share an id →
  `EntityInfo` lookups cross-wire → fatal `AccessViolationException` deep in
  `Chunk.GetArray`
- a slot write lands in the **stale** array → the live `Worlds` array holds
  `null` for a freshly created world → `NullReferenceException` in
  `EntityExtensions.Get` / `World.Get` immediately after `Create`

Readers (`EntityExtensions`, the generated accessors) also index `Worlds` with
no publication barrier, so on weakly-ordered CPUs (ARM64) a resized array can
become visible before its copied contents.

We hit this constantly in CI (12 of 15 recent failed runs on our project) with
NUnit fixtures creating worlds in parallel; the victim test differed every run,
and about a third of the failures escalated to a fatal AV that killed the test
host.

### Fix

- Guard create/destroy with a dedicated `WorldsLock` object whose identity
  never changes.
- On resize, fill the new world's slot in the copy **before** publishing the
  array with `Volatile.Write`; non-resize slot writes are volatile element
  writes.
- Readers stay lock-free and unchanged: element loads carry an address
  dependency on the array reference, so release-publication is sufficient.
  No hot-path cost.

### Tests

- `ConcurrentWorldCreateProducesUniqueUsableWorlds` — 8 threads × 64 worlds
  created concurrently (forcing several resizes), each world used immediately
  through the static lookup, then id-uniqueness and slot identity asserted.
- `ConcurrentWorldCreateDestroyChurnDoesNotCorruptStaticStorage` — 8 threads ×
  200 create/use/destroy rounds so id recycling, slot writes and resizes
  interleave.
- `WorldRecycle` now drains the recycled-id queue before asserting reuse, so it
  no longer depends on the queue being empty when the fixture runs.

Both new tests fail against the current locking in 3/3 runs (NRE / duplicate
ids) and pass with the fix. The test file is `#if !PURE_ECS` — the static
registry it exercises does not exist under PURE_ECS. Full suite green
(net8.0, Debug + Release × Default / Events / PureECS).
